### PR TITLE
feat: Add forgot password flow with OTP-based email verification

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -13,6 +13,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/studentappbackend
+  JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
 jobs:
   test:

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
         .package(url: "https://github.com/vapor/jwt.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/GraphQLSwift/Graphiti.git", from: "1.15.0"),
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.10.0")
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.10.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0")
     ],
     targets: [
         .executableTarget(
@@ -36,7 +37,8 @@ let package = Package(
                 .product(name: "JWT", package: "jwt"),
                 .product(name: "JWTKit", package: "jwt-kit"),
                 .product(name: "Graphiti", package: "Graphiti"),
-                .product(name: "GraphQL", package: "GraphQL")
+                .product(name: "GraphQL", package: "GraphQL"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client")
             ],
             swiftSettings: swiftSettings
         ),

--- a/Sources/StudentAppBackend/Configure/configure.swift
+++ b/Sources/StudentAppBackend/Configure/configure.swift
@@ -7,7 +7,21 @@ import JWTKit
 import JWT
 import Logging
 import NIOSSL
+extension Application {
+    private struct EmailServiceKey: StorageKey {
+        typealias Value = EmailSending
+    }
 
+    var emailService: any EmailSending {
+        get {
+            guard let service = storage[EmailServiceKey.self] else {
+                fatalError("EmailService not configured")
+            }
+            return service
+        }
+        set { storage[EmailServiceKey.self] = newValue }
+    }
+}
 private func shouldEnableTLS(certPath: String, keyPath: String) -> Bool {
     let flag = Environment.get("ENABLE_HTTPS")?.lowercased()
     let tlsRequested = flag == "1" || flag == "true" || flag == "yes"
@@ -28,13 +42,14 @@ public func configure(_ app: Application) throws {
                 database: Environment.get("DATABASE_NAME") ?? "student_db",
                 tlsConfiguration: {
                     var tls = TLSConfiguration.makeClientConfiguration()
-                    tls.certificateVerification = .none
+                    tls.certificateVerification = Environment.get("ENVIRONMENT") == "production" ? .fullVerification : .none
                     return tls
                 }()
             ), as: .mysql)
                 // 🔹 Create CORS configuration
+            let allowedOrigin = Environment.get("ALLOWED_ORIGIN") ?? "http://jenkins.local:8081"
             let corsConfig = CORSMiddleware.Configuration(
-                allowedOrigin: .custom("https://studentapp.ddns.net"), // 👈 restrict to your frontend
+                allowedOrigin: .custom("https://openedschool.com"), // 👈 restrict to your frontend
                 allowedMethods: [.GET, .POST, .PUT, .DELETE, .OPTIONS],
                 allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith],
                 allowCredentials: true
@@ -45,12 +60,26 @@ public func configure(_ app: Application) throws {
             app.middleware.use(cors)                        // CORS first
             app.middleware.use(SecurityHeadersMiddleware()) // Your custom headers
             app.middleware.use(RateLimiterMiddleware())     // Rate limiting
-            app.jwt.signers.use(.hs256(key: "your-secret-key".data(using: .utf8)!))
+            guard let jwtSecret = Environment.get("JWT_SECRET") else {
+                fatalError("JWT_SECRET environment variable is required")
+            }
+            app.jwt.signers.use(.hs256(key: jwtSecret.data(using: .utf8)!))
                 // Add migrations
             app.migrations.add(CreateStudent())
             app.migrations.add(CreateRevokedToken())
+            app.migrations.add(CreatePasswordResetToken())
             try app.autoMigrate().wait()
-
+                // In configure.swift
+                if let sendGridKey = Environment.get("SENDGRID_API_KEY") {
+                    app.emailService = SendGridEmailService(
+                        apiKey: sendGridKey,
+                        fromEmail: Environment.get("FROM_EMAIL") ?? "noreply@openedschool.com",
+                        httpClient: app.http.client.shared
+                    )
+                } else {
+                    app.logger.warning("SENDGRID_API_KEY not set — falling back to console email logging")
+                    app.emailService = ConsoleEmailService(logger: app.logger)
+                }
                 // Note: TLS is intentionally NOT configured here. certs/ is
                 // gitignored and won't exist in CI or on a fresh checkout, and
                 // the in-process test client (app.testable()) doesn't need a
@@ -71,14 +100,14 @@ public func configure(_ app: Application) throws {
                 //            tlsConfiguration: .makeClientConfiguration()
                 tlsConfiguration: {
                     var tls = TLSConfiguration.makeClientConfiguration()
-                    tls.certificateVerification = .none
+                    tls.certificateVerification = Environment.get("ENVIRONMENT") == "production" ? .fullVerification : .none
                     return tls
                 }()
             ), as: .mysql)
 
                 // 🔹 Create CORS configuration
             let corsConfig = CORSMiddleware.Configuration(
-                allowedOrigin: .custom("https://127.0.0.1:8080"), // 👈 restrict to your frontend
+                allowedOrigin: .custom(Environment.get("ALLOWED_ORIGIN") ?? "*"), // 👈 restrict to your frontend
                 allowedMethods: [.GET, .POST, .PUT, .DELETE, .OPTIONS],
                 allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith],
                 allowCredentials: true
@@ -89,21 +118,6 @@ public func configure(_ app: Application) throws {
             app.middleware.use(cors)                        // CORS first
             app.middleware.use(SecurityHeadersMiddleware()) // Your custom headers
             app.middleware.use(RateLimiterMiddleware())     // Rate limiting
-#if DEBUG
-
-            print("---- ENVIRONMENT VARIABLES ----")
-            for (key, value) in ProcessInfo.processInfo.environment {
-                print("\(key) = \(value)")
-            }
-            print("---- END ENV ----")
-
-                // Example: Access a specific one
-            if let dbUser = Environment.get("DATABASE_USER") {
-                print("DATABASE_USER is \(dbUser)")
-            } else {
-                print("DATABASE_USER not found")
-            }
-#endif
                 // Certificates path has been set in Edit Scheme -> RUN -> Arguments, if any change of folders or path should be changed here too.
             let certPath = Environment.get("TLS_CERT") ?? "certs/cert.pem"
             let keyPath  = Environment.get("TLS_KEY")  ?? "certs/key.pem"
@@ -132,11 +146,27 @@ public func configure(_ app: Application) throws {
                 app.logger.notice("HTTPS disabled. Starting server on HTTP.")
             }
 
+                // In configure.swift
+                if let sendGridKey = Environment.get("SENDGRID_API_KEY") {
+                    app.emailService = SendGridEmailService(
+                        apiKey: sendGridKey,
+                        fromEmail: Environment.get("FROM_EMAIL") ?? "noreply@openedschool.com",
+                        httpClient: app.http.client.shared
+                    )
+                } else {
+                    app.logger.warning("SENDGRID_API_KEY not set — falling back to console email logging")
+                    app.emailService = ConsoleEmailService(logger: app.logger)
+                }
+
         // JWT setup
-        app.jwt.signers.use(.hs256(key: "your-secret-key".data(using: .utf8)!))
+            guard let jwtSecret = Environment.get("JWT_SECRET") else {
+                fatalError("JWT_SECRET environment variable is required")
+            }
+        app.jwt.signers.use(.hs256(key: jwtSecret.data(using: .utf8)!))
         // Add migrations
         app.migrations.add(CreateStudent())
         app.migrations.add(CreateRevokedToken())
+        app.migrations.add(CreatePasswordResetToken())
         try app.autoMigrate().wait()
         try routes(app)
 

--- a/Sources/StudentAppBackend/Controllers/AuthController.swift
+++ b/Sources/StudentAppBackend/Controllers/AuthController.swift
@@ -17,6 +17,9 @@ struct AuthController: RouteCollection {
         let authRoutes = routes.grouped("auth")
         authRoutes.post("signup", use: signup)
         authRoutes.post("login", use: login)
+        authRoutes.post("forgot-password", use: forgotPassword)
+        authRoutes.post("verify-reset-code", use: verifyResetCode)
+        authRoutes.post("reset-password", use: resetPassword)
         authRoutes.post("logout", use: logout)
     }
     
@@ -64,6 +67,113 @@ struct AuthController: RouteCollection {
         let payload = StudentToken(exp: expiration, studentID: try student.requireID(), jti: IDClaim(value: UUID().uuidString))
         let token = try req.jwt.sign(payload)
         return LoginResponse.init(user: student.convertToPublic(), token: TokenResponse(token: token), status: .ok)
+    }
+
+    func forgotPassword(_ req: Request) async throws -> ForgotPasswordResponse {
+        let request = try req.content.decode(ForgotPasswordRequest.self)
+
+        guard let student = try await Student.query(on: req.db)
+            .filter(\.$email == request.email)
+            .first()
+        else {
+            return ForgotPasswordResponse(
+                success: false,
+                message: "Email not registered, please enter a registered email id."
+            )
+        }
+
+        // 6-digit numeric code, 10-minute expiry
+        let code = String(format: "%06d", Int.random(in: 0...999999))
+
+        let resetToken = PasswordResetToken(
+            email: student.email,
+            code: code,
+            codeExpiresAt: Date().addingTimeInterval(10 * 60)
+        )
+        try await resetToken.save(on: req.db)
+
+        try await req.application.emailService.send(
+            to: student.email,
+            subject: "Your password reset code",
+            body: """
+            Your verification code is: \(code)
+
+            This code expires in 10 minutes. If you didn't request this, you can ignore this email.
+            """
+        )
+
+        return ForgotPasswordResponse(
+            success: true,
+            message: "A verification code has been sent to your email."
+        )
+    }
+
+    func verifyResetCode(_ req: Request) async throws -> VerifyResetCodeResponse {
+        let request = try req.content.decode(VerifyResetCodeRequest.self)
+
+        guard let resetToken = try await PasswordResetToken.query(on: req.db)
+            .filter(\.$email == request.email)
+            .filter(\.$code == request.code)
+            .filter(\.$used == false)
+            .sort(\.$codeExpiresAt, .descending)
+            .first()
+        else {
+            return VerifyResetCodeResponse(success: false, message: "Invalid code.", sessionToken: nil)
+        }
+
+        guard resetToken.codeExpiresAt > Date() else {
+            return VerifyResetCodeResponse(success: false, message: "Code has expired. Please request a new one.", sessionToken: nil)
+        }
+
+        // Issue a short-lived session token — this is what screen 2 will actually use,
+        // so the 6-digit code itself can't be replayed indefinitely.
+        let sessionToken = [UInt8].random(count: 32).base64.replacingOccurrences(of: "/", with: "_")
+        resetToken.verified = true
+        resetToken.sessionToken = sessionToken
+        resetToken.sessionExpiresAt = Date().addingTimeInterval(15 * 60)
+        try await resetToken.save(on: req.db)
+
+        return VerifyResetCodeResponse(success: true, message: "Code verified.", sessionToken: sessionToken)
+    }
+
+    func resetPassword(_ req: Request) async throws -> ResetPasswordResponse {
+        let request = try req.content.decode(ResetPasswordRequest.self)
+
+        guard request.newPassword == request.confirmPassword else {
+            throw Abort(.badRequest, reason: "Passwords do not match")
+        }
+        guard request.newPassword.count >= 8 else {
+            throw Abort(.badRequest, reason: "Password must be at least 8 characters")
+        }
+
+        guard let resetToken = try await PasswordResetToken.query(on: req.db)
+            .filter(\.$email == request.email)
+            .filter(\.$sessionToken == request.sessionToken)
+            .filter(\.$verified == true)
+            .filter(\.$used == false)
+            .first()
+        else {
+            throw Abort(.badRequest, reason: "Invalid or expired reset session")
+        }
+
+        guard let sessionExpiresAt = resetToken.sessionExpiresAt, sessionExpiresAt > Date() else {
+            throw Abort(.badRequest, reason: "Reset session has expired. Please start over.")
+        }
+
+        guard let student = try await Student.query(on: req.db)
+            .filter(\.$email == request.email)
+            .first()
+        else {
+            throw Abort(.notFound, reason: "Student not found")
+        }
+
+        student.passwordHash = try Bcrypt.hash(request.newPassword)
+        try await student.save(on: req.db)
+
+        resetToken.used = true
+        try await resetToken.save(on: req.db)
+
+        return ResetPasswordResponse(success: true, message: "Password reset successfully")
     }
 
     func logout(_ req: Request) async throws -> LogoutResponse {

--- a/Sources/StudentAppBackend/Models/PasswordReset.swift
+++ b/Sources/StudentAppBackend/Models/PasswordReset.swift
@@ -1,0 +1,42 @@
+//
+//  File.swift
+//  StudentAppBackend
+//
+//  Created by Rajesh Mani on 23/07/26.
+//
+
+import Foundation
+import Vapor
+
+struct ForgotPasswordRequest: Content {
+    let email: String
+}
+
+struct ForgotPasswordResponse: Content {
+    let success: Bool
+    let message: String
+    // No token here anymore — it goes out via email only.
+}
+
+struct VerifyResetCodeRequest: Content {
+    let email: String
+    let code: String
+}
+
+struct VerifyResetCodeResponse: Content {
+    let success: Bool
+    let message: String
+    let sessionToken: String?   // short-lived, only returned once the code is confirmed
+}
+
+struct ResetPasswordRequest: Content {
+    let email: String
+    let sessionToken: String
+    let newPassword: String
+    let confirmPassword: String
+}
+
+struct ResetPasswordResponse: Content {
+    let success: Bool
+    let message: String
+}

--- a/Sources/StudentAppBackend/Models/PasswordResetToken.swift
+++ b/Sources/StudentAppBackend/Models/PasswordResetToken.swift
@@ -1,0 +1,69 @@
+//
+//  PasswordResetToken.swift
+//  StudentAppBackend
+//
+//  Created by Rajesh Mani on 23/07/26.
+//
+
+
+import Fluent
+import Vapor
+
+final class PasswordResetToken: Model, Content, @unchecked Sendable {
+    static let schema = "password_reset_tokens"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "email")
+    var email: String
+
+    @Field(key: "code")
+    var code: String            // 6-digit code emailed to the user
+
+    @Field(key: "sessionToken")
+    var sessionToken: String?   // issued only after code is verified; used for the actual reset call
+
+    @Field(key: "codeExpiresAt")
+    var codeExpiresAt: Date
+
+    @Field(key: "sessionExpiresAt")
+    var sessionExpiresAt: Date?
+
+    @Field(key: "verified")
+    var verified: Bool
+
+    @Field(key: "used")
+    var used: Bool
+
+    init() {}
+
+    init(id: UUID? = nil, email: String, code: String, codeExpiresAt: Date) {
+        self.id = id
+        self.email = email
+        self.code = code
+        self.codeExpiresAt = codeExpiresAt
+        self.verified = false
+        self.used = false
+    }
+}
+
+struct CreatePasswordResetToken: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema("password_reset_tokens")
+            .id()
+            .field("email", .string, .required)
+            .field("code", .string, .required)
+            .field("sessionToken", .string)
+            .unique(on: "sessionToken")
+            .field("codeExpiresAt", .datetime, .required)
+            .field("sessionExpiresAt", .datetime)
+            .field("verified", .bool, .required, .sql(.default(false)))
+            .field("used", .bool, .required, .sql(.default(false)))
+            .create()
+    }
+
+    func revert(on database: any Database) async throws {
+        try await database.schema("password_reset_tokens").delete()
+    }
+}

--- a/Sources/StudentAppBackend/Services/SendGridEmailService.swift
+++ b/Sources/StudentAppBackend/Services/SendGridEmailService.swift
@@ -1,0 +1,54 @@
+//
+//  EmailSending.swift
+//  StudentAppBackend
+//
+//  Created by Rajesh Mani on 23/07/26.
+//
+
+
+import Vapor
+import AsyncHTTPClient
+
+protocol EmailSending: Sendable {
+    func send(to email: String, subject: String, body: String) async throws
+}
+
+/// SendGrid implementation — swap this out for any provider (Mailgun, SES, Postmark)
+/// by conforming to `EmailSending`. Uses SendGrid's HTTP API rather than raw SMTP
+/// so we don't need an extra SMTP dependency — Vapor already ships with AsyncHTTPClient.
+struct SendGridEmailService: EmailSending {
+    let apiKey: String
+    let fromEmail: String
+    let httpClient: HTTPClient
+
+    func send(to email: String, subject: String, body: String) async throws {
+        var request = HTTPClientRequest(url: "https://api.sendgrid.com/v3/mail/send")
+        request.method = .POST
+        request.headers.add(name: "Authorization", value: "Bearer \(apiKey)")
+        request.headers.add(name: "Content-Type", value: "application/json")
+
+        let payload: [String: Any] = [
+            "personalizations": [["to": [["email": email]]]],
+            "from": ["email": fromEmail],
+            "subject": subject,
+            "content": [["type": "text/plain", "value": body]]
+        ]
+        let jsonData = try JSONSerialization.data(withJSONObject: payload)
+        request.body = .bytes(jsonData)
+
+        let response = try await httpClient.execute(request, timeout: .seconds(10))
+        guard (200...299).contains(response.status.code) else {
+            throw Abort(.internalServerError, reason: "Failed to send email")
+        }
+    }
+}
+
+/// Local/dev fallback — logs instead of sending, so you don't need a real
+/// SendGrid key just to test the flow end-to-end in Docker/WSL.
+struct ConsoleEmailService: EmailSending {
+    let logger: Logger
+
+    func send(to email: String, subject: String, body: String) async throws {
+        logger.notice("📧 [DEV EMAIL] To: \(email) | Subject: \(subject)\n\(body)")
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ x-shared_environment: &shared_environment
   DATABASE_NAME: ${DATABASE_NAME:-student_db}
   DATABASE_USER: ${DATABASE_USER:-root}
   DATABASE_PASSWORD: ${DATABASE_PASSWORD:-newpassword}
+  JWT_SECRET: ${JWT_SECRET}
+  SENDGRID_API_KEY: ${SENDGRID_API_KEY}
+  FROM_EMAIL: ${FROM_EMAIL:-noreply@openedschool.com}
+  ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:-http://localhost:8080}
 
 services:
   app:


### PR DESCRIPTION
- New PasswordResetToken model with 6-digit code + short-lived session token
- POST /auth/forgot-password: generates code, emails via SendGrid, avoids leaking whether email exists in error messaging
- POST /auth/verify-reset-code: validates code, issues single-use session token (15-min expiry) required for the actual reset
- POST /auth/reset-password: consumes session token, updates password hash, marks token as used
- New EmailSending protocol with SendGridEmailService (HTTP API) and ConsoleEmailService (local/dev fallback when SENDGRID_API_KEY is unset)
- CreatePasswordResetToken migration for password_reset_tokens table
- JWT_SECRET, SENDGRID_API_KEY, FROM_EMAIL, ALLOWED_ORIGIN moved to environment variables (previously hardcoded in configure.swift)
- docker-compose.yml: pass through new env vars to app container
