### PR TITLE
feat(tls): Automate Self-Signed Certificate Renewal for Development (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ TLS_CERT=certs/cert.pem
 TLS_KEY=certs/key.pem
 TLS_MIN_VERSION=1.2
 # TLS_CIPHER_SUITES=ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305
+# Automated Dev Certificate Renewal (development only; strictly ignored in production)
+AUTO_RENEW_DEV_CERTS=true
+DEV_CERT_RENEWAL_THRESHOLD_DAYS=30
 
 # HSTS (HTTP Strict Transport Security)
 # Defaults: false in development/testing, true in production

--- a/README.md
+++ b/README.md
@@ -508,27 +508,39 @@ The current test suite includes cases for:
 
 ### Native Local HTTPS
 
-If running the Vapor app directly and you want local HTTPS, generate a self-signed certificate with `CN=localhost`.
+If running the Vapor app directly with local HTTPS (`ENABLE_HTTPS=true`), self-signed certificates with modern Subject Alternative Names (`DNS:localhost, IP:127.0.0.1, IP:::1`) are automatically managed.
 
-1. Generate the certificate and key.
+#### 1. Automated Certificate Renewal Script
 
-```bash
-openssl req -x509 -newkey rsa:2048 -nodes \
-  -keyout key.pem -out cert.pem -days 365 \
-  -subj "/CN=localhost"
-```
-
-2. Export a `.p12` bundle if needed.
+Use [`scripts/renew-dev-certs.sh`](scripts/renew-dev-certs.sh) to inspect, generate, or renew development certificates:
 
 ```bash
-openssl pkcs12 -export -out localhost.p12 \
-  -inkey key.pem -in cert.pem \
-  -name "Vapor Localhost Cert"
+# Check if certificates are healthy without modifying files
+./scripts/renew-dev-certs.sh --check-only
+
+# Generate or renew certificates (idempotent: skips if valid > 30 days)
+./scripts/renew-dev-certs.sh
+
+# Force regeneration immediately
+./scripts/renew-dev-certs.sh --force
 ```
 
-3. Import `cert.pem` into macOS Keychain and set it to trust for local use.
-4. Restart the Vapor application so it reloads the certificates.
-5. Test the endpoint again.
+The script automatically generates:
+- `certs/cert.pem` (Public X.509 certificate with SAN extensions; `0644`)
+- `certs/key.pem` (2048-bit RSA private key; `0600`)
+- `certs/localhost.p12` (PKCS#12 bundle for Keychain & iOS Simulator trust; `0600`)
+
+#### 2. Automatic Startup Pre-Flight Check
+
+When `ENABLE_HTTPS=true` is set in `.development`, `CertificateManager` automatically inspects certificate expiration during server startup (`configureTLS`). If missing or expiring within 30 days (`DEV_CERT_RENEWAL_THRESHOLD_DAYS`), it automatically refreshes them (can be disabled with `AUTO_RENEW_DEV_CERTS=false`).
+
+*Note: Self-signed certificate auto-renewal is strictly forbidden in `.production`.*
+
+#### 3. Trusting the Certificate for Local Testing
+
+Import `certs/cert.pem` or `certs/localhost.p12` into macOS Keychain (or iOS Simulator) and mark it as trusted for SSL.
+
+Then test local HTTPS:
 
 ```bash
 curl https://localhost:8080/auth/login \

--- a/README.md
+++ b/README.md
@@ -523,6 +523,9 @@ Use [`scripts/renew-dev-certs.sh`](scripts/renew-dev-certs.sh) to inspect, gener
 
 # Force regeneration immediately
 ./scripts/renew-dev-certs.sh --force
+
+# Custom password for PKCS#12 bundle (defaults to empty password)
+./scripts/renew-dev-certs.sh --p12-pass "mypassword"
 ```
 
 The script automatically generates:
@@ -541,7 +544,7 @@ When `ENABLE_HTTPS=true` is set in `.development`, `CertificateManager` automati
 Import `certs/cert.pem` or `certs/localhost.p12` into macOS Keychain (or iOS Simulator) and mark it as trusted for SSL.
 
 > [!NOTE]
-> `certs/localhost.p12` uses an empty password by design for frictionless local development and iOS Simulator trust store imports. It is restricted by `0600` permissions (owner-accessible only), gitignored, and strictly forbidden in production.
+> `certs/localhost.p12` defaults to an empty password (`pass:`) for frictionless local development and iOS Simulator trust store imports without password prompts. A custom password can optionally be supplied via `--p12-pass <PASSWORD>`. The bundle is restricted by `0600` permissions (owner-accessible only), gitignored, and strictly forbidden in production.
 
 Then test local HTTPS:
 

--- a/README.md
+++ b/README.md
@@ -540,6 +540,9 @@ When `ENABLE_HTTPS=true` is set in `.development`, `CertificateManager` automati
 
 Import `certs/cert.pem` or `certs/localhost.p12` into macOS Keychain (or iOS Simulator) and mark it as trusted for SSL.
 
+> [!NOTE]
+> `certs/localhost.p12` uses an empty password by design for frictionless local development and iOS Simulator trust store imports. It is restricted by `0600` permissions (owner-accessible only), gitignored, and strictly forbidden in production.
+
 Then test local HTTPS:
 
 ```bash

--- a/Sources/StudentAppBackend/Configure/AppConfig.swift
+++ b/Sources/StudentAppBackend/Configure/AppConfig.swift
@@ -329,10 +329,10 @@ enum AppConfig {
     }
 
     /// Number of days before certificate expiration to trigger an automated renewal warning or refresh.
-    /// Defaults to 30 days. Configurable via DEV_CERT_RENEWAL_THRESHOLD_DAYS.
+    /// Defaults to 30 days. Configurable via DEV_CERT_RENEWAL_THRESHOLD_DAYS (must be non-negative).
     static func devCertRenewalThresholdDays(for environment: Environment) -> Int {
         guard let raw = Environment.get("DEV_CERT_RENEWAL_THRESHOLD_DAYS")?.trimmingCharacters(in: .whitespacesAndNewlines),
-              let days = Int(raw), days >= 1 else {
+              let days = Int(raw), days >= 0 else {
             return 30
         }
         return days

--- a/Sources/StudentAppBackend/Configure/AppConfig.swift
+++ b/Sources/StudentAppBackend/Configure/AppConfig.swift
@@ -312,4 +312,29 @@ enum AppConfig {
             return environment == .production ? .verifyFull : .noVerify
         }
     }
+
+    // MARK: - Development Certificate Auto-Renewal
+
+    /// Determines whether development TLS certificates should be automatically generated/renewed if expired or missing.
+    /// In .development, defaults to true unless explicitly disabled with AUTO_RENEW_DEV_CERTS=false/0/no/off.
+    /// In .production and .testing, defaults to false (strictly prohibited in production).
+    static func autoRenewDevCerts(for environment: Environment) -> Bool {
+        guard environment != .production else {
+            return false
+        }
+        guard let raw = Environment.get("AUTO_RENEW_DEV_CERTS")?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else {
+            return environment == .development
+        }
+        return raw == "1" || raw == "true" || raw == "yes" || raw == "on"
+    }
+
+    /// Number of days before certificate expiration to trigger an automated renewal warning or refresh.
+    /// Defaults to 30 days. Configurable via DEV_CERT_RENEWAL_THRESHOLD_DAYS.
+    static func devCertRenewalThresholdDays(for environment: Environment) -> Int {
+        guard let raw = Environment.get("DEV_CERT_RENEWAL_THRESHOLD_DAYS")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let days = Int(raw), days >= 1 else {
+            return 30
+        }
+        return days
+    }
 }

--- a/Sources/StudentAppBackend/Configure/configure.swift
+++ b/Sources/StudentAppBackend/Configure/configure.swift
@@ -127,6 +127,15 @@ func configureTLS(_ app: Application) throws {
 
     let certPath = Environment.get("TLS_CERT") ?? "certs/cert.pem"
     let keyPath = Environment.get("TLS_KEY") ?? "certs/key.pem"
+
+    let flag = Environment.get("ENABLE_HTTPS")?.lowercased()
+    let tlsRequested = flag == "1" || flag == "true" || flag == "yes"
+
+    // In development environments, run certificate pre-flight check if HTTPS is requested
+    if tlsRequested && app.environment == .development {
+        _ = try? CertificateManager.ensureDevelopmentCertificates(app: app)
+    }
+
     let tlsEnabled = shouldEnableTLS(certPath: certPath, keyPath: keyPath)
 
     #if DEBUG

--- a/Sources/StudentAppBackend/Services/CertificateManager.swift
+++ b/Sources/StudentAppBackend/Services/CertificateManager.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 import Vapor
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 /// Represents the health and lifecycle status of an X.509 certificate.
 enum CertificateStatus: Equatable, Sendable {
@@ -75,6 +80,8 @@ struct CertificateManager: Sendable {
     }
 
     /// Renews development certificates in the specified directory.
+    /// Note: Default SAN "DNS:localhost,IP:127.0.0.1,IP:::1" contains "IP:::1" representing
+    /// the "IP:" prefix concatenated with IPv6 loopback literal "::1".
     /// Strictly prohibited when environment == .production.
     @discardableResult
     static func renewDevelopmentCertificates(
@@ -126,7 +133,17 @@ struct CertificateManager: Sendable {
             }
             exitCode = runProcess(executable: "/bin/bash", arguments: [scriptPath] + args)
         } else {
-            // Fallback direct OpenSSL generation if script is not found
+            // Fallback direct OpenSSL generation if script is not found.
+            // Temporarily set POSIX umask 0077 so newly created private key & PKCS#12 bundle
+            // are initialized with 0600 permissions atomically without any permission race condition window.
+            #if canImport(Darwin)
+            let prevUmask = Darwin.umask(0o077)
+            defer { _ = Darwin.umask(prevUmask) }
+            #elseif canImport(Glibc)
+            let prevUmask = Glibc.umask(0o077)
+            defer { _ = Glibc.umask(prevUmask) }
+            #endif
+
             let certExit = runOpenSSLProcess([
                 "req", "-x509", "-nodes", "-newkey", "rsa:2048",
                 "-keyout", keyFile,
@@ -287,9 +304,23 @@ struct CertificateManager: Sendable {
 
     // MARK: - Process Execution Helpers
 
+    private static var openSSLExecutablePath: String {
+        let candidates = [
+            "/usr/bin/openssl",
+            "/usr/local/bin/openssl",
+            "/opt/homebrew/bin/openssl"
+        ]
+        for path in candidates {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+        return "/usr/bin/openssl"
+    }
+
     private static func runOpenSSL(_ arguments: [String]) -> String? {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/openssl")
+        process.executableURL = URL(fileURLWithPath: openSSLExecutablePath)
         process.arguments = arguments
 
         let pipe = Pipe()
@@ -308,7 +339,7 @@ struct CertificateManager: Sendable {
     }
 
     private static func runOpenSSLProcess(_ arguments: [String]) -> Int32 {
-        runProcess(executable: "/usr/bin/openssl", arguments: arguments)
+        runProcess(executable: openSSLExecutablePath, arguments: arguments)
     }
 
     private static func runProcess(executable: String, arguments: [String]) -> Int32 {

--- a/Sources/StudentAppBackend/Services/CertificateManager.swift
+++ b/Sources/StudentAppBackend/Services/CertificateManager.swift
@@ -83,12 +83,13 @@ struct CertificateManager: Sendable {
         thresholdDays: Int = 30,
         force: Bool = false,
         sans: String = "DNS:localhost,IP:127.0.0.1,IP:::1",
+        p12Password: String = "",
         environment: Environment = .development
     ) throws -> CertificateStatus {
         guard environment != .production else {
             throw Abort(
                 .internalServerError,
-                reason: "Self-signed certificate auto-renewal is strictly forbidden in production."
+                reason: "FATAL: Self-signed certificate auto-renewal is strictly forbidden in production. Use trusted CA or ACME certificates."
             )
         }
 
@@ -117,6 +118,9 @@ struct CertificateManager: Sendable {
                 "--threshold", "\(thresholdDays)",
                 "--san", sans
             ]
+            if !p12Password.isEmpty {
+                args.append(contentsOf: ["--p12-pass", p12Password])
+            }
             if force {
                 args.append("--force")
             }
@@ -132,14 +136,14 @@ struct CertificateManager: Sendable {
                 "-addext", "subjectAltName=\(sans)"
             ])
             let p12File = (certDir as NSString).appendingPathComponent("localhost.p12")
-            // Export PKCS#12 bundle with empty password for seamless dev/simulator keychain import
+            // Export PKCS#12 bundle with empty password (or specified p12Password) for keychain import
             _ = runOpenSSLProcess([
                 "pkcs12", "-export",
                 "-out", p12File,
                 "-inkey", keyFile,
                 "-in", certFile,
                 "-name", "Vapor Localhost Cert",
-                "-passout", "pass:"
+                "-passout", "pass:\(p12Password)"
             ])
             try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyFile)
             try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: p12File)
@@ -234,9 +238,50 @@ struct CertificateManager: Sendable {
     }
 
     private static func validateSANs(_ sans: String) throws {
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:,-")
-        guard sans.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
-            throw Abort(.badRequest, reason: "Invalid SANs: only alphanumeric, commas, dots, colons, hyphens, and underscores are allowed.")
+        guard !sans.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw Abort(.badRequest, reason: "Invalid SANs: subjectAltName cannot be empty.")
+        }
+
+        let tokens = sans.split(separator: ",", omittingEmptySubsequences: false).map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        for token in tokens {
+            guard !token.isEmpty else {
+                throw Abort(.badRequest, reason: "Invalid SANs: empty token found in '\(sans)'.")
+            }
+
+            if token.hasPrefix("DNS:") {
+                let hostname = String(token.dropFirst(4))
+                guard !hostname.contains("_") else {
+                    throw Abort(.badRequest, reason: "Invalid DNS SAN '\(token)': underscores are not permitted in DNS hostnames.")
+                }
+                guard !hostname.hasPrefix(".") && !hostname.hasSuffix(".") &&
+                      !hostname.hasPrefix("-") && !hostname.hasSuffix("-") else {
+                    throw Abort(.badRequest, reason: "Invalid DNS SAN '\(token)': cannot start or end with '.' or '-'.")
+                }
+                let dnsAllowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-")
+                guard hostname.unicodeScalars.allSatisfy({ dnsAllowed.contains($0) }) else {
+                    throw Abort(.badRequest, reason: "Invalid DNS SAN '\(token)': contains invalid characters.")
+                }
+            } else if token.hasPrefix("IP:") {
+                let ip = String(token.dropFirst(3))
+                let ipAllowed = CharacterSet(charactersIn: "0123456789abcdefABCDEF:.")
+                guard ip.unicodeScalars.allSatisfy({ ipAllowed.contains($0) }) else {
+                    throw Abort(.badRequest, reason: "Invalid IP SAN '\(token)': contains invalid characters.")
+                }
+                // If IPv4, validate octets <= 255
+                let octets = ip.split(separator: ".")
+                if octets.count == 4 {
+                    for octet in octets {
+                        guard let val = Int(octet), val >= 0, val <= 255 else {
+                            throw Abort(.badRequest, reason: "Invalid IPv4 SAN '\(token)': octet out of range.")
+                        }
+                    }
+                }
+            } else {
+                throw Abort(.badRequest, reason: "Invalid SAN token '\(token)'. Only 'DNS:<hostname>' and 'IP:<address>' are permitted.")
+            }
         }
     }
 

--- a/Sources/StudentAppBackend/Services/CertificateManager.swift
+++ b/Sources/StudentAppBackend/Services/CertificateManager.swift
@@ -1,0 +1,267 @@
+//
+//  CertificateManager.swift
+//  StudentAppBackend
+//
+//  Created by Rajesh Mani on 12/09/26.
+//
+
+import Foundation
+import Vapor
+
+/// Represents the health and lifecycle status of an X.509 certificate.
+enum CertificateStatus: Equatable, Sendable {
+    case valid(daysRemaining: Int, expiresAt: String)
+    case expiringSoon(daysRemaining: Int, expiresAt: String)
+    case expired(expiredAt: String)
+    case missing(path: String)
+    case invalid(reason: String)
+
+    var isHealthy: Bool {
+        if case .valid = self { return true }
+        return false
+    }
+
+    var requiresRenewal: Bool {
+        switch self {
+        case .expired, .expiringSoon, .missing:
+            return true
+        case .valid, .invalid:
+            return false
+        }
+    }
+}
+
+/// Service to inspect, validate, and renew self-signed TLS certificates for development.
+struct CertificateManager: Sendable {
+
+    /// Inspects the certificate file at the given path and calculates remaining validity days.
+    static func checkCertificateStatus(
+        certPath: String,
+        keyPath: String? = nil,
+        thresholdDays: Int = 30
+    ) -> CertificateStatus {
+        guard FileManager.default.fileExists(atPath: certPath) else {
+            return .missing(path: certPath)
+        }
+
+        if let keyPath = keyPath, !FileManager.default.fileExists(atPath: keyPath) {
+            return .missing(path: keyPath)
+        }
+
+        // Fetch expiration date string via openssl
+        guard let endDateOutput = runOpenSSL(["x509", "-in", certPath, "-enddate", "-noout"]),
+              let rawDate = endDateOutput.split(separator: "=").last?
+                  .trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return .invalid(reason: "Unable to parse certificate expiration date")
+        }
+
+        // Check if certificate has already expired
+        let expiredCheck = runOpenSSLProcess(["x509", "-in", certPath, "-checkend", "0", "-noout"])
+        if expiredCheck != 0 {
+            return .expired(expiredAt: rawDate)
+        }
+
+        // Check if certificate expires within threshold seconds
+        let thresholdSeconds = "\(thresholdDays * 86400)"
+        let expiringSoonCheck = runOpenSSLProcess(["x509", "-in", certPath, "-checkend", thresholdSeconds, "-noout"])
+        if expiringSoonCheck != 0 {
+            // Rough estimation of days remaining
+            let daysRemaining = estimateDaysRemaining(certPath: certPath) ?? thresholdDays
+            return .expiringSoon(daysRemaining: daysRemaining, expiresAt: rawDate)
+        }
+
+        let daysRemaining = estimateDaysRemaining(certPath: certPath) ?? 365
+        return .valid(daysRemaining: daysRemaining, expiresAt: rawDate)
+    }
+
+    /// Renews development certificates in the specified directory.
+    /// Strictly prohibited when environment == .production.
+    @discardableResult
+    static func renewDevelopmentCertificates(
+        certDir: String = "certs",
+        days: Int = 365,
+        thresholdDays: Int = 30,
+        force: Bool = false,
+        sans: String = "DNS:localhost,IP:127.0.0.1,IP:::1",
+        environment: Environment = .development
+    ) throws -> CertificateStatus {
+        guard environment != .production else {
+            throw Abort(
+                .internalServerError,
+                reason: "Self-signed certificate auto-renewal is strictly forbidden in production."
+            )
+        }
+
+        let certFile = (certDir as NSString).appendingPathComponent("cert.pem")
+        let keyFile = (certDir as NSString).appendingPathComponent("key.pem")
+
+        if !force {
+            let currentStatus = checkCertificateStatus(certPath: certFile, keyPath: keyFile, thresholdDays: thresholdDays)
+            if case .valid = currentStatus {
+                return currentStatus
+            }
+        }
+
+        try FileManager.default.createDirectory(atPath: certDir, withIntermediateDirectories: true)
+
+        let scriptPath = "scripts/renew-dev-certs.sh"
+        let exitCode: Int32
+
+        if FileManager.default.fileExists(atPath: scriptPath) {
+            var args = [
+                "--cert-dir", certDir,
+                "--days", "\(days)",
+                "--threshold", "\(thresholdDays)",
+                "--san", sans
+            ]
+            if force {
+                args.append("--force")
+            }
+            exitCode = runProcess(executable: "/bin/bash", arguments: [scriptPath] + args)
+        } else {
+            // Fallback direct OpenSSL generation if script is not found
+            let certExit = runOpenSSLProcess([
+                "req", "-x509", "-nodes", "-newkey", "rsa:2048",
+                "-keyout", keyFile,
+                "-out", certFile,
+                "-days", "\(days)",
+                "-subj", "/CN=localhost",
+                "-addext", "subjectAltName=\(sans)"
+            ])
+            let p12File = (certDir as NSString).appendingPathComponent("localhost.p12")
+            _ = runOpenSSLProcess([
+                "pkcs12", "-export",
+                "-out", p12File,
+                "-inkey", keyFile,
+                "-in", certFile,
+                "-name", "Vapor Localhost Cert",
+                "-passout", "pass:"
+            ])
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyFile)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: certFile)
+            exitCode = certExit
+        }
+
+        guard exitCode == 0 else {
+            throw Abort(
+                .internalServerError,
+                reason: "Failed to renew development certificates (process exited with code \(exitCode))."
+            )
+        }
+
+        return checkCertificateStatus(certPath: certFile, keyPath: keyFile, thresholdDays: thresholdDays)
+    }
+
+    /// Pre-flight check run during server configuration in non-production environments.
+    @discardableResult
+    static func ensureDevelopmentCertificates(app: Application) throws -> CertificateStatus {
+        guard app.environment != .production else {
+            return .valid(daysRemaining: 365, expiresAt: "production-ca")
+        }
+
+        let certPath = Environment.get("TLS_CERT") ?? "certs/cert.pem"
+        let keyPath = Environment.get("TLS_KEY") ?? "certs/key.pem"
+        let certDir = (certPath as NSString).deletingLastPathComponent
+        let threshold = AppConfig.devCertRenewalThresholdDays(for: app.environment)
+        let autoRenew = AppConfig.autoRenewDevCerts(for: app.environment)
+
+        let status = checkCertificateStatus(certPath: certPath, keyPath: keyPath, thresholdDays: threshold)
+
+        switch status {
+        case .valid(let days, let expiresAt):
+            app.logger.notice("TLS certificate is healthy (\(days) days remaining, expires: \(expiresAt)).")
+            return status
+
+        case .expiringSoon(let days, let expiresAt):
+            if autoRenew {
+                app.logger.warning("TLS certificate is expiring soon (\(days) days remaining, expires: \(expiresAt)). Auto-renewing...")
+                let newStatus = try renewDevelopmentCertificates(certDir: certDir.isEmpty ? "certs" : certDir, thresholdDays: threshold, force: true, environment: app.environment)
+                app.logger.notice("TLS certificate auto-renewed successfully.")
+                return newStatus
+            } else {
+                app.logger.warning("TLS certificate expires in \(days) days. Run './scripts/renew-dev-certs.sh' to renew.")
+                return status
+            }
+
+        case .expired(let expiredAt):
+            if autoRenew {
+                app.logger.warning("TLS certificate expired on \(expiredAt). Auto-renewing for development...")
+                let newStatus = try renewDevelopmentCertificates(certDir: certDir.isEmpty ? "certs" : certDir, thresholdDays: threshold, force: true, environment: app.environment)
+                app.logger.notice("TLS certificate auto-renewed successfully.")
+                return newStatus
+            } else {
+                app.logger.error("TLS certificate expired on \(expiredAt). Run './scripts/renew-dev-certs.sh' to renew.")
+                return status
+            }
+
+        case .missing(let path):
+            if autoRenew {
+                app.logger.notice("TLS certificate not found at '\(path)'. Generating new self-signed certificate...")
+                let newStatus = try renewDevelopmentCertificates(certDir: certDir.isEmpty ? "certs" : certDir, thresholdDays: threshold, force: true, environment: app.environment)
+                app.logger.notice("TLS certificate generated successfully.")
+                return newStatus
+            } else {
+                app.logger.warning("TLS certificate missing at '\(path)'. Run './scripts/renew-dev-certs.sh' to generate.")
+                return status
+            }
+
+        case .invalid(let reason):
+            app.logger.error("TLS certificate at '\(certPath)' is invalid: \(reason).")
+            return status
+        }
+    }
+
+    // MARK: - Process Execution Helpers
+
+    private static func runOpenSSL(_ arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/openssl")
+        process.arguments = arguments
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func runOpenSSLProcess(_ arguments: [String]) -> Int32 {
+        runProcess(executable: "/usr/bin/openssl", arguments: arguments)
+    }
+
+    private static func runProcess(executable: String, arguments: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        } catch {
+            return -1
+        }
+    }
+
+    private static func estimateDaysRemaining(certPath: String) -> Int? {
+        // Test intervals: 1 day, 7 days, 14 days, 30 days, 60 days, 90 days, 180 days, 365 days
+        let dayIntervals = [1, 7, 14, 30, 60, 90, 180, 270, 365]
+        for days in dayIntervals {
+            let seconds = "\(days * 86400)"
+            if runOpenSSLProcess(["x509", "-in", certPath, "-checkend", seconds, "-noout"]) != 0 {
+                return days
+            }
+        }
+        return 365
+    }
+}

--- a/Sources/StudentAppBackend/Services/CertificateManager.swift
+++ b/Sources/StudentAppBackend/Services/CertificateManager.swift
@@ -92,6 +92,9 @@ struct CertificateManager: Sendable {
             )
         }
 
+        try validateDirectoryPath(certDir)
+        try validateSANs(sans)
+
         let certFile = (certDir as NSString).appendingPathComponent("cert.pem")
         let keyFile = (certDir as NSString).appendingPathComponent("key.pem")
 
@@ -129,6 +132,7 @@ struct CertificateManager: Sendable {
                 "-addext", "subjectAltName=\(sans)"
             ])
             let p12File = (certDir as NSString).appendingPathComponent("localhost.p12")
+            // Export PKCS#12 bundle with empty password for seamless dev/simulator keychain import
             _ = runOpenSSLProcess([
                 "pkcs12", "-export",
                 "-out", p12File,
@@ -138,6 +142,7 @@ struct CertificateManager: Sendable {
                 "-passout", "pass:"
             ])
             try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: keyFile)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: p12File)
             try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: certFile)
             exitCode = certExit
         }
@@ -211,6 +216,30 @@ struct CertificateManager: Sendable {
         }
     }
 
+    // MARK: - Path and Input Validation
+
+    private static func validateDirectoryPath(_ path: String) throws {
+        guard !path.contains("..") else {
+            throw Abort(.badRequest, reason: "Invalid certificate directory: directory traversal '..' is forbidden.")
+        }
+        guard !path.contains("\0") else {
+            throw Abort(.badRequest, reason: "Invalid certificate directory: null bytes are forbidden.")
+        }
+        let sensitiveDirs = ["/", "/etc", "/dev", "/sys", "/proc", "/bin", "/usr", "/sbin"]
+        for dir in sensitiveDirs {
+            if path == dir || path.hasPrefix(dir + "/") {
+                throw Abort(.forbidden, reason: "Invalid certificate directory: targeting sensitive system directory '\(path)' is forbidden.")
+            }
+        }
+    }
+
+    private static func validateSANs(_ sans: String) throws {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:,-")
+        guard sans.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {
+            throw Abort(.badRequest, reason: "Invalid SANs: only alphanumeric, commas, dots, colons, hyphens, and underscores are allowed.")
+        }
+    }
+
     // MARK: - Process Execution Helpers
 
     private static func runOpenSSL(_ arguments: [String]) -> String? {
@@ -220,13 +249,13 @@ struct CertificateManager: Sendable {
 
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = FileHandle.nullDevice
 
         do {
             try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             guard process.terminationStatus == 0 else { return nil }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
             return String(data: data, encoding: .utf8)
         } catch {
             return nil
@@ -241,8 +270,8 @@ struct CertificateManager: Sendable {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
         do {
             try process.run()

--- a/Specs/automate-self-signed-certificate-renewal/architecture.md
+++ b/Specs/automate-self-signed-certificate-renewal/architecture.md
@@ -1,0 +1,81 @@
+# Architecture: Automated Self-Signed Certificate Renewal for Development
+
+## 1. Overview
+This document outlines the architectural lifecycle, operational boundaries, and security design for automated self-signed certificate generation and renewal in `StudentAppBackend`.
+
+## 2. Component Diagram & Lifecycle Flow
+
+```
++-------------------------------------------------------------------------------+
+| Developer / CI / Docker Runner                                                |
++-------------------------------------------------------------------------------+
+         |
+         | (1) Manual / Pre-build CLI invocation: ./scripts/renew-dev-certs.sh
+         v
++-------------------------------------------------------------------------------+
+| scripts/renew-dev-certs.sh (Portable Shell CLI)                               |
+| - Inspects certs/cert.pem using openssl x509 -checkend <threshold>           |
+| - If valid (> threshold days): exits 0 without modifying files               |
+| - If expired / missing / --force:                                             |
+|   1. Generates 2048-bit RSA key (key.pem, chmod 600)                          |
+|   2. Generates X.509 cert with SANs (cert.pem, chmod 644)                     |
+|   3. Exports PKCS#12 bundle (localhost.p12, chmod 600)                        |
++-------------------------------------------------------------------------------+
+         |
+         | Writes files to certs/ directory
+         v
++-------------------------------------------------------------------------------+
+| certs/ directory                                                              |
+| - cert.pem       (Public X.509 Certificate with SAN extensions)               |
+| - key.pem        (Private Key - 0600 permissions)                             |
+| - localhost.p12  (PKCS#12 bundle for Keychain / Simulator trust)              |
++-------------------------------------------------------------------------------+
+         ^
+         |
+         | (2) Runtime Pre-flight check in configureTLS
++-------------------------------------------------------------------------------+
+| Vapor Backend Application Server                                              |
+|                                                                               |
+|  [configureTLS]                                                               |
+|    |                                                                          |
+|    +---> [AppConfig.autoRenewDevCerts]                                        |
+|            |                                                                  |
+|            +---> Check: app.environment == .development                       |
+|            |                                                                  |
+|            +---> [CertificateManager.ensureDevelopmentCertificates]           |
+|            |       - Checks cert status via OpenSSL / File inspection         |
+|            |       - If missing/expiring: auto-renews via CLI execution       |
+|            |       - If .production: STRICT NO-OP / ABORT                     |
+|            |                                                                  |
+|            v                                                                  |
+|  [SwiftNIO SSL TLSConfiguration]                                              |
+|    - Loads certs/cert.pem & certs/key.pem                                     |
+|    - Binds HTTPS listener with TLS 1.2+ & AEAD ciphers                        |
++-------------------------------------------------------------------------------+
+```
+
+## 3. Security Boundary & Production Guardrails
+
+| Attribute | Development (`.development`) | Production (`.production`) |
+| :--- | :--- | :--- |
+| **Certificate Authority** | Self-Signed (`CN=localhost`) | Trusted Public CA / Let's Encrypt / ACME |
+| **Auto-Renewal Source** | Local `scripts/renew-dev-certs.sh` | Reverse proxy (Caddy/Nginx) or Platform Ingress |
+| **Key Permissions** | `0600` (Owner read/write only) | `0600` (Mounted via Kubernetes / Docker Secret) |
+| **Runtime Generation** | Allowed when `AUTO_RENEW_DEV_CERTS=true` | **Strictly Forbidden** (Causes startup failure) |
+| **Pre-flight Behavior** | Auto-generates or warns if expired | Fail-fast validation in `validateProductionSecrets` |
+
+## 4. Subject Alternative Names (SAN) Architecture
+Modern TLS clients (macOS Safari, Google Chrome 58+, Mozilla Firefox, iOS URLSession) deprecate checking `commonName` alone and require the `subjectAltName` extension.
+
+Generated certificates mandate:
+```ini
+subjectAltName = DNS:localhost, IP:127.0.0.1, IP:::1
+```
+This guarantees that local connections to `https://localhost:8080`, `https://127.0.0.1:8080`, and `https://[::1]:8080` all pass TLS hostname verification.
+
+## 5. Script & Command Interface
+The CLI script exposes a POSIX-compliant interface:
+- `./scripts/renew-dev-certs.sh --check-only` (exit 0 if valid, 1 if renewal needed)
+- `./scripts/renew-dev-certs.sh --force` (immediate regeneration)
+- `./scripts/renew-dev-certs.sh --days 365 --threshold 30` (custom validity and renewal windows)
+- `./scripts/renew-dev-certs.sh --cert-dir <PATH>` (sandbox directory testing)

--- a/Specs/automate-self-signed-certificate-renewal/architecture.md
+++ b/Specs/automate-self-signed-certificate-renewal/architecture.md
@@ -79,15 +79,17 @@ The CLI script exposes a POSIX-compliant interface:
 - `./scripts/renew-dev-certs.sh --force` (immediate regeneration)
 - `./scripts/renew-dev-certs.sh --days 365 --threshold 30` (custom validity and renewal windows)
 - `./scripts/renew-dev-certs.sh --cert-dir <PATH>` (sandbox directory testing)
+- `./scripts/renew-dev-certs.sh --p12-pass <PASSWORD>` (custom password protection for PKCS#12 bundle)
 
 ## 6. Security Hardening & Vulnerability Mitigations
 
 | Vulnerability Vector | Mitigation Mechanism | Implementation Detail |
 | :--- | :--- | :--- |
-| **Shell Injection via SANs** | Whitelist validation & explicit quoting | Both script and Swift validate SANs against `^[A-Za-z0-9_.:,-]+$`. Quoted expansion in openssl calls. |
+| **Shell Injection via SANs** | Token-by-token validation & explicit quoting | Both script and Swift validate every token: `DNS:<hostname>` (rejects underscores) and `IP:<address>` (IPv4 octet <= 255, IPv6). Quoted expansion in OpenSSL calls. |
 | **Input Validation** | Strict numeric bounds checking | `--days` must be positive integer (`>= 1`); `--threshold` must be non-negative integer (`>= 0`). |
 | **Path Traversal** | Traversal & system path blacklisting | Rejects `..` sequences, null bytes, and sensitive system root paths (`/`, `/etc`, `/dev`, `/bin`, `/usr`, `/proc`, `/sys`). |
 | **Key Exposure Race Condition** | Inode creation `umask 0077` | Script applies `umask 0077` before file creation, guaranteeing private keys and PKCS#12 bundles are created with `0600` permissions. |
-| **PKCS#12 Password Security** | Local development restriction & file isolation | Empty password (`pass:`) intentionally used for seamless macOS Keychain & iOS Simulator trust store import without prompts. Protected by `0600` permissions and forbidden in production. |
+| **PKCS#12 Password Security** | Local development restriction & configurable password | Defaults to empty password (`pass:`) for seamless macOS Keychain & iOS Simulator trust store import without prompts; supports custom password via `--p12-pass`. Protected by `0600` permissions. |
 | **Subprocess Pipe Deadlocks** | `FileHandle.nullDevice` non-blocking pipes | Process stderr/stdout discarded directly to null device when unneeded, avoiding 64KB OS pipe buffer exhaustion deadlocks. |
+| **Orphaned Temp Files** | POSIX Trap Handler (`EXIT INT TERM`) | Trap handler guarantees temporary fallback OpenSSL configs are unlinked upon normal exit or error. |
 

--- a/Specs/automate-self-signed-certificate-renewal/architecture.md
+++ b/Specs/automate-self-signed-certificate-renewal/architecture.md
@@ -79,3 +79,15 @@ The CLI script exposes a POSIX-compliant interface:
 - `./scripts/renew-dev-certs.sh --force` (immediate regeneration)
 - `./scripts/renew-dev-certs.sh --days 365 --threshold 30` (custom validity and renewal windows)
 - `./scripts/renew-dev-certs.sh --cert-dir <PATH>` (sandbox directory testing)
+
+## 6. Security Hardening & Vulnerability Mitigations
+
+| Vulnerability Vector | Mitigation Mechanism | Implementation Detail |
+| :--- | :--- | :--- |
+| **Shell Injection via SANs** | Whitelist validation & explicit quoting | Both script and Swift validate SANs against `^[A-Za-z0-9_.:,-]+$`. Quoted expansion in openssl calls. |
+| **Input Validation** | Strict numeric bounds checking | `--days` must be positive integer (`>= 1`); `--threshold` must be non-negative integer (`>= 0`). |
+| **Path Traversal** | Traversal & system path blacklisting | Rejects `..` sequences, null bytes, and sensitive system root paths (`/`, `/etc`, `/dev`, `/bin`, `/usr`, `/proc`, `/sys`). |
+| **Key Exposure Race Condition** | Inode creation `umask 0077` | Script applies `umask 0077` before file creation, guaranteeing private keys and PKCS#12 bundles are created with `0600` permissions. |
+| **PKCS#12 Password Security** | Local development restriction & file isolation | Empty password (`pass:`) intentionally used for seamless macOS Keychain & iOS Simulator trust store import without prompts. Protected by `0600` permissions and forbidden in production. |
+| **Subprocess Pipe Deadlocks** | `FileHandle.nullDevice` non-blocking pipes | Process stderr/stdout discarded directly to null device when unneeded, avoiding 64KB OS pipe buffer exhaustion deadlocks. |
+

--- a/Specs/automate-self-signed-certificate-renewal/spec.md
+++ b/Specs/automate-self-signed-certificate-renewal/spec.md
@@ -71,8 +71,19 @@ This feature operates at the infrastructure/tooling layer. No REST or GraphQL en
 No database tables, migrations, or queries required.
 
 ## 11. Security Requirements
-- Restrictive file permissions: private keys (`key.pem`) and PKCS#12 bundles (`localhost.p12`) restricted to owner permissions (`0600`).
-- Strict environment isolation: production environments require valid CA certificates and reject auto-renewal.
+- **SEC-001 (Input Validation)**:
+  - `--days` must be an integer >= 1.
+  - `--threshold` must be an integer >= 0.
+  - `--san` must strictly match regex `^[A-Za-z0-9_.:,-]+$`.
+- **SEC-002 (Path Traversal Protection)**:
+  - `--cert-dir` and Swift `certDir` must disallow directory traversal (`..`) and null bytes (`\0`).
+  - Sensitive system roots (`/`, `/etc`, `/dev`, `/sys`, `/proc`, `/bin`, `/usr`, `/sbin`) are explicitly forbidden.
+- **SEC-003 (File Permission Atomicity)**:
+  - Inode creation permissions are governed by `umask 0077`, ensuring private keys (`key.pem`) and PKCS#12 bundles (`localhost.p12`) are created with `0600` mode without any race condition window. Public cert is adjusted to `0644`.
+- **SEC-004 (PKCS#12 Password Security)**:
+  - Development `.p12` bundle uses empty password (`pass:`) intentionally for zero-friction macOS Keychain & iOS Simulator imports. It is strictly forbidden in `.production` and guarded by `0600` permissions.
+- **SEC-005 (Subprocess Pipe Reliability)**:
+  - Subprocess pipes for discarded output use `FileHandle.nullDevice` to eliminate OS buffer deadlock risks.
 
 ## 12. Concurrency Requirements
 - File generation runs sequentially during server initialization or CLI execution before concurrent worker threads accept incoming TLS connections.
@@ -88,6 +99,7 @@ No database tables, migrations, or queries required.
 - **AC-003**: Given a valid certificate with >30 days remaining, when `./scripts/renew-dev-certs.sh` runs without `--force`, it exits cleanly without re-generating files.
 - **AC-004**: Given `./scripts/renew-dev-certs.sh --check-only`, it exits with 0 for valid certs and 1 for expiring/missing certs without writing files.
 - **AC-005**: Given `app.environment == .production`, `CertificateManager` refuses to renew self-signed certificates and throws an error.
+- **AC-006**: Given malicious or invalid inputs (`--san`, `--days`, `--threshold`, `--cert-dir`), the system fails fast with error status 1 and prevents injection.
 
 ## 15. Test Scenarios
 ### Unit Tests
@@ -97,10 +109,26 @@ No database tables, migrations, or queries required.
 - `testCertificateRenewalExecution`: creates valid certificate with SANs and correct permissions.
 - `testCertificateRenewalIdempotency`: does not regenerate when certificate is healthy.
 - `testProductionSafetyGuard`: rejects renewal when environment is production.
+- `certificateCLISecurityValidation`: verifies script rejects invalid numeric values, directory traversal, sensitive system directories, and SAN injection attempts.
+- `certificateManagerSecurityValidation`: verifies Swift service rejects directory traversal, system paths, and invalid SAN characters.
 
 ### Integration Tests
 - Run `scripts/renew-dev-certs.sh --check-only` and `--force` in a temporary test directory.
 - Verify server startup with `ENABLE_HTTPS=true` under `.development` automatically ensures valid certificates.
+
+### Manual Security Testing Checklist (CHK-010)
+
+| Test ID | Vulnerability Tested | Test Command | Expected Output & Code |
+| :--- | :--- | :--- | :--- |
+| **SEC-TEST-01** | Shell Injection via SANs | `./scripts/renew-dev-certs.sh --san "DNS:localhost; rm -rf /"` | `Error: --san contains invalid characters...` (Exit: 1) |
+| **SEC-TEST-02** | Command Substitution via SANs | `./scripts/renew-dev-certs.sh --san 'DNS:localhost`id`'` | `Error: --san contains invalid characters...` (Exit: 1) |
+| **SEC-TEST-03** | Non-numeric `--days` | `./scripts/renew-dev-certs.sh --days abc` | `Error: --days must be a positive integer` (Exit: 1) |
+| **SEC-TEST-04** | Negative / Zero `--days` | `./scripts/renew-dev-certs.sh --days 0` | `Error: --days must be a positive integer` (Exit: 1) |
+| **SEC-TEST-05** | Negative `--threshold` | `./scripts/renew-dev-certs.sh --threshold -5` | `Error: --threshold must be a non-negative integer` (Exit: 1) |
+| **SEC-TEST-06** | Directory Traversal (`..`) | `./scripts/renew-dev-certs.sh --cert-dir "../sensitive"` | `Error: --cert-dir cannot contain directory traversal '..'` (Exit: 1) |
+| **SEC-TEST-07** | Sensitive System Path Target | `./scripts/renew-dev-certs.sh --cert-dir "/etc"` | `Error: --cert-dir cannot target sensitive system directories` (Exit: 1) |
+| **SEC-TEST-08** | Inode Permission Atomicity | `umask; ./scripts/renew-dev-certs.sh --force; stat -f "%Lp %N" certs/*` | Key/P12: `600`, Cert: `644` (Exit: 0) |
+| **SEC-TEST-09** | Production Environment Block | Run app in `.production` with `CertificateManager.renewDevelopmentCertificates()` | Throws `Abort(.internalServerError)` |
 
 ## 16. Observability
 - Server logs notice/warning on startup indicating certificate status, days remaining, and whether automatic renewal was executed.

--- a/Specs/automate-self-signed-certificate-renewal/spec.md
+++ b/Specs/automate-self-signed-certificate-renewal/spec.md
@@ -37,7 +37,7 @@ In `StudentAppBackend`, local development over HTTPS relies on self-signed X.509
 ## 5. Functional Requirements
 - **FR-001**: The system MUST inspect the expiration date (`notAfter`) of an existing certificate file and calculate remaining validity days.
 - **FR-002**: When a certificate is missing, expired, or expiring within `<threshold>` days (default: 30 days), the system MUST support regenerating a 2048-bit RSA private key and self-signed X.509 certificate.
-- **FR-003**: The generated certificate MUST include Subject Alternative Names (SAN) containing at least `DNS:localhost`, `IP:127.0.0.1`, and `IP:::1`.
+- **FR-003**: The generated certificate MUST include Subject Alternative Names (SAN) containing at least `DNS:localhost`, `IP:127.0.0.1`, and `IP:::1` (where `IP:::1` represents OpenSSL's `IP:` prefix concatenated with the IPv6 loopback literal `::1`).
 - **FR-004**: The system MUST support bundling the private key and certificate into a PKCS#12 file (`localhost.p12`) with an empty password.
 - **FR-005**: The system MUST set POSIX permissions to `0600` (read/write for owner only) for the private key and `.p12` file, and `0644` for the public certificate.
 - **FR-006**: The standalone script (`scripts/renew-dev-certs.sh`) MUST support:

--- a/Specs/automate-self-signed-certificate-renewal/spec.md
+++ b/Specs/automate-self-signed-certificate-renewal/spec.md
@@ -1,0 +1,112 @@
+# Feature: Automate Self-Signed Certificate Renewal for Development
+
+## 1. Problem
+In `StudentAppBackend`, local development over HTTPS relies on self-signed X.509 certificates located in `certs/` (`cert.pem`, `key.pem`, and `localhost.p12`).
+1. **Certificate Expiration Outages**: Self-signed certificates generated for development expire after 365 days. When they expire, local HTTPS requests fail with SSL errors (e.g. `SSL: CERTIFICATE_VERIFY_FAILED`, `ERR_CERT_DATE_INVALID`), blocking frontend (iOS/web) and backend testing.
+2. **Setup Friction**: New developers setting up on fresh machines or CI environments without pre-generated certificates face startup failures when `ENABLE_HTTPS=true` is requested.
+3. **Manual Overhead & Non-Standard Generation**: Developers currently follow manual OpenSSL CLI instructions in the README. Inconsistent commands often omit modern Subject Alternative Names (`subjectAltName = DNS:localhost, IP:127.0.0.1, IP:::1`), causing modern browsers and iOS HTTP clients to reject the certificates.
+4. **No Automated Health or Pre-Flight Checks**: The server has no automated mechanism in development to detect that certificates are near expiration or to automatically refresh them before developer disruption occurs.
+
+## 2. Goal
+1. Provide an automated, cross-platform CLI tool (`scripts/renew-dev-certs.sh`) to inspect, generate, and renew development certificates.
+2. Provide an application-level `CertificateManager` service that checks certificate status on startup in non-production environments and auto-renews when enabled.
+3. Enforce modern Subject Alternative Names (`DNS:localhost, IP:127.0.0.1, IP:::1`) and secure file permissions (`0600` for keys and PKCS#12 bundles, `0644` for public certs).
+4. Strictly protect production environments (`.production`) by preventing self-signed certificate generation or auto-renewal, requiring trusted CA / ACME certificates.
+5. Provide comprehensive automated unit and integration tests verifying inspection, renewal, and security boundaries.
+
+## 3. Scope
+### In Scope
+- Shell automation tool `scripts/renew-dev-certs.sh` supporting `--check-only`, `--force`, `--days`, `--threshold`, `--cert-dir`, `--san`.
+- `CertificateManager` Swift service in `Sources/StudentAppBackend/Services/CertificateManager.swift`.
+- Pre-flight check integration in `configureTLS` in `configure.swift`.
+- Configuration flags in `AppConfig` (`autoRenewDevCerts`, `devCertRenewalThresholdDays`).
+- PKCS#12 bundle (`localhost.p12`) generation for macOS Keychain and iOS simulator trust.
+- Unit and integration tests in `StudentAppBackendTests.swift`.
+- Documentation in `.env.example` and `README.md`.
+
+### Out of Scope
+- Production ACME / Let's Encrypt client implementation (production TLS is handled at edge reverse proxies or platform ingress).
+- Modifying OS-level trust stores (trusting the certificate in Keychain or browser remains a user action).
+
+## 4. Actors
+- **Developer**: Runs local development server or CLI renewal script.
+- **CI / Docker Runner**: Automatically generates development certificates during container or test setup.
+- **Vapor Backend Application**: Inspects certificate health during startup pre-flight.
+- **Client (iOS StudyApp / Web Browser)**: Communicates with backend over HTTPS.
+
+## 5. Functional Requirements
+- **FR-001**: The system MUST inspect the expiration date (`notAfter`) of an existing certificate file and calculate remaining validity days.
+- **FR-002**: When a certificate is missing, expired, or expiring within `<threshold>` days (default: 30 days), the system MUST support regenerating a 2048-bit RSA private key and self-signed X.509 certificate.
+- **FR-003**: The generated certificate MUST include Subject Alternative Names (SAN) containing at least `DNS:localhost`, `IP:127.0.0.1`, and `IP:::1`.
+- **FR-004**: The system MUST support bundling the private key and certificate into a PKCS#12 file (`localhost.p12`) with an empty password.
+- **FR-005**: The system MUST set POSIX permissions to `0600` (read/write for owner only) for the private key and `.p12` file, and `0644` for the public certificate.
+- **FR-006**: The standalone script (`scripts/renew-dev-certs.sh`) MUST support:
+  - `--check-only`: Returns exit code 0 if certificate is valid beyond threshold; returns exit code 1 if missing, expired, or expiring.
+  - `--force`: Unconditionally regenerates new certificates.
+  - `--days <N>`: Sets validity duration in days (default: 365).
+  - `--threshold <N>`: Sets expiration warning/renewal threshold in days (default: 30).
+  - `--cert-dir <DIR>`: Sets destination directory (default: `certs/`).
+- **FR-007**: When `ENABLE_HTTPS=true` and `app.environment == .development`, `configureTLS` MUST run a certificate health pre-flight check. If `AUTO_RENEW_DEV_CERTS=true` (default in dev), it MUST automatically renew expiring or missing certificates.
+- **FR-008**: Self-signed certificate generation or auto-renewal MUST be strictly disabled in `.production`.
+
+## 6. Non-Functional Requirements
+- **NFR-001 (Security)**: Private keys must never be world-readable. Auto-renewal must never execute in production.
+- **NFR-002 (Portability)**: The CLI script must be POSIX-compliant and run without external dependencies beyond standard `openssl` on macOS (Darwin) and Linux (Ubuntu, Debian, Alpine, WSL, Docker).
+- **NFR-003 (Idempotency)**: Running the script or pre-flight check on an already valid certificate must be a fast, safe no-op.
+- **NFR-004 (Performance)**: Certificate validity check must take < 50ms during startup.
+
+## 7. Business Rules
+- **BR-001**: Production servers must never generate self-signed certificates at runtime.
+- **BR-002**: Development certificates must remain valid for 365 days by default, with automatic renewal triggered when less than 30 days remain.
+- **BR-003**: Default SAN list must cover localhost IPv4 and IPv6 loopback addresses.
+
+## 8. Validation Rules
+- **VAL-001**: `--days` and `--threshold` must be positive integers.
+- **VAL-002**: Destination directory must be created if not already existing.
+
+## 9. API Contract
+This feature operates at the infrastructure/tooling layer. No REST or GraphQL endpoints are modified.
+
+## 10. Database Requirements
+No database tables, migrations, or queries required.
+
+## 11. Security Requirements
+- Restrictive file permissions: private keys (`key.pem`) and PKCS#12 bundles (`localhost.p12`) restricted to owner permissions (`0600`).
+- Strict environment isolation: production environments require valid CA certificates and reject auto-renewal.
+
+## 12. Concurrency Requirements
+- File generation runs sequentially during server initialization or CLI execution before concurrent worker threads accept incoming TLS connections.
+
+## 13. Error Handling
+- If OpenSSL is missing from PATH, script exits with code 127 and diagnostic message.
+- If certificate generation fails, previous certificate files are not corrupted.
+- In production, attempting self-signed auto-renewal throws `Abort(.internalServerError, reason: "Self-signed certificate auto-renewal is forbidden in production")`.
+
+## 14. Acceptance Criteria
+- **AC-001**: Given no certificates in `certs/`, when `./scripts/renew-dev-certs.sh` is executed, valid `cert.pem`, `key.pem`, and `localhost.p12` are generated with modern SANs and correct permissions.
+- **AC-002**: Given a certificate expiring within 30 days or already expired, when `./scripts/renew-dev-certs.sh` runs, new certificates with 365-day validity are generated.
+- **AC-003**: Given a valid certificate with >30 days remaining, when `./scripts/renew-dev-certs.sh` runs without `--force`, it exits cleanly without re-generating files.
+- **AC-004**: Given `./scripts/renew-dev-certs.sh --check-only`, it exits with 0 for valid certs and 1 for expiring/missing certs without writing files.
+- **AC-005**: Given `app.environment == .production`, `CertificateManager` refuses to renew self-signed certificates and throws an error.
+
+## 15. Test Scenarios
+### Unit Tests
+- `testCertificateStatusMissing`: detects non-existent certificate file.
+- `testCertificateStatusExpired`: detects expired certificate.
+- `testCertificateStatusExpiringSoon`: detects certificate expiring within threshold.
+- `testCertificateRenewalExecution`: creates valid certificate with SANs and correct permissions.
+- `testCertificateRenewalIdempotency`: does not regenerate when certificate is healthy.
+- `testProductionSafetyGuard`: rejects renewal when environment is production.
+
+### Integration Tests
+- Run `scripts/renew-dev-certs.sh --check-only` and `--force` in a temporary test directory.
+- Verify server startup with `ENABLE_HTTPS=true` under `.development` automatically ensures valid certificates.
+
+## 16. Observability
+- Server logs notice/warning on startup indicating certificate status, days remaining, and whether automatic renewal was executed.
+
+## 17. Open Questions
+None. All requirements clarified and approved.
+
+## 18. Assumptions
+- OpenSSL (v1.1.1+ or v3.0+) is available in standard developer and container environments.

--- a/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
+++ b/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
@@ -2363,6 +2363,17 @@ struct StudentAppBackendTests {
         #expect(runScriptWithArgs(["--san", "DNS:localhost`id`"]) != 0)
         #expect(runScriptWithArgs(["--san", "DNS:localhost' OR 1=1--"]) != 0)
         #expect(runScriptWithArgs(["--san", "DNS:localhost$HOME"]) != 0)
+
+        // Rejects underscores in DNS SANs (RFC 1035 / RFC 1123)
+        #expect(runScriptWithArgs(["--san", "DNS:my_server.local"]) != 0)
+
+        // Rejects invalid prefixes or empty SANs
+        #expect(runScriptWithArgs(["--san", "URI:http://localhost"]) != 0)
+        #expect(runScriptWithArgs(["--san", "EMAIL:test@example.com"]) != 0)
+        #expect(runScriptWithArgs(["--san", ""]) != 0)
+
+        // Rejects invalid IPv4 octets
+        #expect(runScriptWithArgs(["--san", "IP:127.0.0.300"]) != 0)
     }
 
     @Test("Certificate: CertificateManager rejects path traversal and invalid SAN characters")
@@ -2385,7 +2396,7 @@ struct StudentAppBackendTests {
             )
         }
 
-        // Invalid SAN rejection
+        // Invalid SAN rejection (shell injection)
         #expect(throws: Abort.self) {
             try CertificateManager.renewDevelopmentCertificates(
                 certDir: "certs",
@@ -2394,6 +2405,56 @@ struct StudentAppBackendTests {
                 environment: .development
             )
         }
+
+        // Rejects DNS SAN with underscores
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "certs",
+                force: true,
+                sans: "DNS:invalid_host.example",
+                environment: .development
+            )
+        }
+
+        // Rejects invalid SAN prefix
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "certs",
+                force: true,
+                sans: "URI:https://localhost",
+                environment: .development
+            )
+        }
+
+        // Rejects out-of-bounds IPv4
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "certs",
+                force: true,
+                sans: "IP:192.168.1.999",
+                environment: .development
+            )
+        }
+    }
+
+    @Test("Certificate: Password-protected PKCS#12 bundle generation")
+    func certificateCustomP12Password() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let status = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            sans: "DNS:localhost,IP:127.0.0.1,IP:::1",
+            p12Password: "CustomSecretPass123!",
+            environment: .development
+        )
+
+        #expect(status.isHealthy)
+        let p12File = (tempDir as NSString).appendingPathComponent("localhost.p12")
+        #expect(FileManager.default.fileExists(atPath: p12File))
     }
 }
 

--- a/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
+++ b/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
@@ -2299,6 +2299,10 @@ struct StudentAppBackendTests {
         setenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS", "45", 1)
         #expect(AppConfig.devCertRenewalThresholdDays(for: .development) == 45)
         unsetenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS")
+
+        setenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS", "0", 1)
+        #expect(AppConfig.devCertRenewalThresholdDays(for: .development) == 0)
+        unsetenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS")
     }
 
     @Test("Certificate: CLI script renew-dev-certs.sh execution and check-only flag")
@@ -2455,6 +2459,51 @@ struct StudentAppBackendTests {
         #expect(status.isHealthy)
         let p12File = (tempDir as NSString).appendingPathComponent("localhost.p12")
         #expect(FileManager.default.fileExists(atPath: p12File))
+    }
+
+    @Test("Certificate: Generated certificate includes Subject Alternative Names (DNS, IPv4, IPv6)")
+    func certificateSANExtensionContents() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let status = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            sans: "DNS:localhost,IP:127.0.0.1,IP:::1",
+            environment: .development
+        )
+        #expect(status.isHealthy)
+
+        let certFile = (tempDir as NSString).appendingPathComponent("cert.pem")
+        #expect(FileManager.default.fileExists(atPath: certFile))
+
+        // Inspect certificate extensions using openssl x509
+        let process = Process()
+        let opensslPath: String
+        let candidates = ["/usr/bin/openssl", "/usr/local/bin/openssl", "/opt/homebrew/bin/openssl"]
+        opensslPath = candidates.first(where: { FileManager.default.fileExists(atPath: $0) }) ?? "/usr/bin/openssl"
+        process.executableURL = URL(fileURLWithPath: opensslPath)
+        process.arguments = ["x509", "-in", certFile, "-text", "-noout"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        let certData = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard let certText = String(data: certData, encoding: .utf8) else {
+            Issue.record("Failed to decode cert text output")
+            return
+        }
+
+        #expect(certText.contains("Subject Alternative Name"))
+        #expect(certText.contains("DNS:localhost"))
+        #expect(certText.contains("127.0.0.1"))
+        #expect(certText.contains("0:0:0:0:0:0:0:1") || certText.contains("::1"))
     }
 }
 

--- a/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
+++ b/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
@@ -2309,8 +2309,8 @@ struct StudentAppBackendTests {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/bash")
         process.arguments = ["scripts/renew-dev-certs.sh", "--cert-dir", tempDir, "--days", "365", "--threshold", "30"]
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
 
         try? process.run()
         process.waitUntilExit()
@@ -2320,12 +2320,80 @@ struct StudentAppBackendTests {
         let checkProcess = Process()
         checkProcess.executableURL = URL(fileURLWithPath: "/bin/bash")
         checkProcess.arguments = ["scripts/renew-dev-certs.sh", "--cert-dir", tempDir, "--check-only"]
-        checkProcess.standardOutput = Pipe()
-        checkProcess.standardError = Pipe()
+        checkProcess.standardOutput = FileHandle.nullDevice
+        checkProcess.standardError = FileHandle.nullDevice
 
         try? checkProcess.run()
         checkProcess.waitUntilExit()
         #expect(checkProcess.terminationStatus == 0)
+    }
+
+    @Test("Certificate: CLI script rejects invalid inputs, path traversal, and injection attempts")
+    func certificateCLISecurityValidation() {
+        let runScriptWithArgs: ([String]) -> Int32 = { args in
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+            proc.arguments = ["scripts/renew-dev-certs.sh"] + args
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
+            return proc.terminationStatus
+        }
+
+        // Rejects non-integer or negative days
+        #expect(runScriptWithArgs(["--days", "abc"]) != 0)
+        #expect(runScriptWithArgs(["--days", "-10"]) != 0)
+        #expect(runScriptWithArgs(["--days", "0"]) != 0)
+
+        // Rejects negative threshold
+        #expect(runScriptWithArgs(["--threshold", "-5"]) != 0)
+        #expect(runScriptWithArgs(["--threshold", "xyz"]) != 0)
+
+        // Rejects directory traversal in cert-dir
+        #expect(runScriptWithArgs(["--cert-dir", "../sensitive"]) != 0)
+        #expect(runScriptWithArgs(["--cert-dir", "/tmp/../etc"]) != 0)
+
+        // Rejects sensitive system directories
+        #expect(runScriptWithArgs(["--cert-dir", "/etc"]) != 0)
+        #expect(runScriptWithArgs(["--cert-dir", "/dev"]) != 0)
+
+        // Rejects shell injection in --san
+        #expect(runScriptWithArgs(["--san", "DNS:localhost; rm -rf /"]) != 0)
+        #expect(runScriptWithArgs(["--san", "DNS:localhost`id`"]) != 0)
+        #expect(runScriptWithArgs(["--san", "DNS:localhost' OR 1=1--"]) != 0)
+        #expect(runScriptWithArgs(["--san", "DNS:localhost$HOME"]) != 0)
+    }
+
+    @Test("Certificate: CertificateManager rejects path traversal and invalid SAN characters")
+    func certificateManagerSecurityValidation() {
+        // Path traversal rejection
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "../unsafe_dir",
+                force: true,
+                environment: .development
+            )
+        }
+
+        // Sensitive system directory rejection
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "/etc/ssl",
+                force: true,
+                environment: .development
+            )
+        }
+
+        // Invalid SAN rejection
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "certs",
+                force: true,
+                sans: "DNS:localhost; echo pwned",
+                environment: .development
+            )
+        }
     }
 }
 

--- a/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
+++ b/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
@@ -2143,10 +2143,25 @@ struct StudentAppBackendTests {
     }
 
     @Test("Certificate: Healthy certificate returns .valid status")
-    func certificateStatusValid() {
+    func certificateStatusValid() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        // Generate a valid certificate first
+        _ = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            environment: .development
+        )
+
+        let certPath = (tempDir as NSString).appendingPathComponent("cert.pem")
+        let keyPath = (tempDir as NSString).appendingPathComponent("key.pem")
+
         let status = CertificateManager.checkCertificateStatus(
-            certPath: "certs/cert.pem",
-            keyPath: "certs/key.pem",
+            certPath: certPath,
+            keyPath: keyPath,
             thresholdDays: 30
         )
         if case .valid(let days, _) = status {
@@ -2159,11 +2174,26 @@ struct StudentAppBackendTests {
     }
 
     @Test("Certificate: High threshold triggers .expiringSoon status")
-    func certificateStatusExpiringSoon() {
+    func certificateStatusExpiringSoon() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        // Generate a valid certificate first
+        _ = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            environment: .development
+        )
+
+        let certPath = (tempDir as NSString).appendingPathComponent("cert.pem")
+        let keyPath = (tempDir as NSString).appendingPathComponent("key.pem")
+
         // Since the certificate is valid for 365 days, a threshold of 400 days makes it 'expiring soon'
         let status = CertificateManager.checkCertificateStatus(
-            certPath: "certs/cert.pem",
-            keyPath: "certs/key.pem",
+            certPath: certPath,
+            keyPath: keyPath,
             thresholdDays: 400
         )
         if case .expiringSoon = status {

--- a/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
+++ b/Tests/StudentAppBackendTests/StudentAppBackendTests.swift
@@ -2126,6 +2126,177 @@ struct StudentAppBackendTests {
                 })
         }
     }
+
+    // MARK: - Certificate Manager & Renewal Tests
+
+    @Test("Certificate: Missing certificate file returns .missing status")
+    func certificateStatusMissing() {
+        let status = CertificateManager.checkCertificateStatus(
+            certPath: "/non/existent/path/cert.pem",
+            keyPath: "/non/existent/path/key.pem"
+        )
+        if case .missing(let path) = status {
+            #expect(path.contains("cert.pem"))
+        } else {
+            #expect(Bool(false), "Expected .missing status, got \(status)")
+        }
+    }
+
+    @Test("Certificate: Healthy certificate returns .valid status")
+    func certificateStatusValid() {
+        let status = CertificateManager.checkCertificateStatus(
+            certPath: "certs/cert.pem",
+            keyPath: "certs/key.pem",
+            thresholdDays: 30
+        )
+        if case .valid(let days, _) = status {
+            #expect(days > 30)
+            #expect(status.isHealthy)
+            #expect(!status.requiresRenewal)
+        } else {
+            #expect(Bool(false), "Expected .valid status for fresh cert, got \(status)")
+        }
+    }
+
+    @Test("Certificate: High threshold triggers .expiringSoon status")
+    func certificateStatusExpiringSoon() {
+        // Since the certificate is valid for 365 days, a threshold of 400 days makes it 'expiring soon'
+        let status = CertificateManager.checkCertificateStatus(
+            certPath: "certs/cert.pem",
+            keyPath: "certs/key.pem",
+            thresholdDays: 400
+        )
+        if case .expiringSoon = status {
+            #expect(status.requiresRenewal)
+        } else {
+            #expect(Bool(false), "Expected .expiringSoon status for 400-day threshold, got \(status)")
+        }
+    }
+
+    @Test("Certificate: Renewal generates valid certificates, SANs, and PKCS#12 bundle")
+    func certificateRenewalExecution() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let status = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            environment: .development
+        )
+
+        #expect(status.isHealthy)
+
+        let certFile = (tempDir as NSString).appendingPathComponent("cert.pem")
+        let keyFile = (tempDir as NSString).appendingPathComponent("key.pem")
+        let p12File = (tempDir as NSString).appendingPathComponent("localhost.p12")
+
+        #expect(FileManager.default.fileExists(atPath: certFile))
+        #expect(FileManager.default.fileExists(atPath: keyFile))
+        #expect(FileManager.default.fileExists(atPath: p12File))
+
+        // Verify POSIX permissions: 0600 on key and p12, 0644 on cert
+        let keyAttrs = try FileManager.default.attributesOfItem(atPath: keyFile)
+        let keyPerms = (keyAttrs[.posixPermissions] as? NSNumber)?.int16Value ?? 0
+        #expect(keyPerms == 0o600)
+
+        let p12Attrs = try FileManager.default.attributesOfItem(atPath: p12File)
+        let p12Perms = (p12Attrs[.posixPermissions] as? NSNumber)?.int16Value ?? 0
+        #expect(p12Perms == 0o600)
+
+        let certAttrs = try FileManager.default.attributesOfItem(atPath: certFile)
+        let certPerms = (certAttrs[.posixPermissions] as? NSNumber)?.int16Value ?? 0
+        #expect(certPerms == 0o644)
+    }
+
+    @Test("Certificate: Renewal is idempotent when certificate is already healthy")
+    func certificateRenewalIdempotency() throws {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        // Initial generation
+        _ = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: true,
+            environment: .development
+        )
+
+        let certFile = (tempDir as NSString).appendingPathComponent("cert.pem")
+        let initialModDate = try FileManager.default.attributesOfItem(atPath: certFile)[.modificationDate] as? Date
+
+        // Second call without force should be a no-op
+        let secondStatus = try CertificateManager.renewDevelopmentCertificates(
+            certDir: tempDir,
+            days: 365,
+            thresholdDays: 30,
+            force: false,
+            environment: .development
+        )
+
+        let secondModDate = try FileManager.default.attributesOfItem(atPath: certFile)[.modificationDate] as? Date
+        #expect(secondStatus.isHealthy)
+        #expect(initialModDate == secondModDate)
+    }
+
+    @Test("Certificate: Production safeguard strictly forbids self-signed auto-renewal")
+    func certificateProductionSafeguard() {
+        #expect(throws: Abort.self) {
+            try CertificateManager.renewDevelopmentCertificates(
+                certDir: "certs",
+                force: true,
+                environment: .production
+            )
+        }
+    }
+
+    @Test("Certificate: AppConfig auto-renewal defaults by environment")
+    func appConfigCertificateSettings() {
+        unsetenv("AUTO_RENEW_DEV_CERTS")
+        unsetenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS")
+
+        #expect(AppConfig.autoRenewDevCerts(for: .development))
+        #expect(!AppConfig.autoRenewDevCerts(for: .production))
+        #expect(!AppConfig.autoRenewDevCerts(for: .testing))
+        #expect(AppConfig.devCertRenewalThresholdDays(for: .development) == 30)
+
+        setenv("AUTO_RENEW_DEV_CERTS", "false", 1)
+        #expect(!AppConfig.autoRenewDevCerts(for: .development))
+        unsetenv("AUTO_RENEW_DEV_CERTS")
+
+        setenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS", "45", 1)
+        #expect(AppConfig.devCertRenewalThresholdDays(for: .development) == 45)
+        unsetenv("DEV_CERT_RENEWAL_THRESHOLD_DAYS")
+    }
+
+    @Test("Certificate: CLI script renew-dev-certs.sh execution and check-only flag")
+    func certificateCLIScriptExecution() {
+        let tempDir = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["scripts/renew-dev-certs.sh", "--cert-dir", tempDir, "--days", "365", "--threshold", "30"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        try? process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+
+        // Run check-only on newly generated valid certificates
+        let checkProcess = Process()
+        checkProcess.executableURL = URL(fileURLWithPath: "/bin/bash")
+        checkProcess.arguments = ["scripts/renew-dev-certs.sh", "--cert-dir", tempDir, "--check-only"]
+        checkProcess.standardOutput = Pipe()
+        checkProcess.standardError = Pipe()
+
+        try? checkProcess.run()
+        checkProcess.waitUntilExit()
+        #expect(checkProcess.terminationStatus == 0)
+    }
 }
 
 // MARK: - Test Request/Response Types

--- a/scripts/renew-dev-certs.sh
+++ b/scripts/renew-dev-certs.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# scripts/renew-dev-certs.sh
+# Automate Self-Signed Certificate Generation and Renewal for Local Development
+#
+# Usage:
+#   ./scripts/renew-dev-certs.sh [OPTIONS]
+#
+# Options:
+#   --check-only      Check certificate validity without renewing (exit 0 if valid, 1 if expired/missing/expiring)
+#   --force           Force certificate regeneration even if currently valid
+#   --days <N>        Certificate validity duration in days (default: 365)
+#   --threshold <N>   Expiration threshold in days to trigger renewal (default: 30)
+#   --cert-dir <DIR>  Directory to store certificates (default: certs)
+#   --san <SANS>      Comma-separated Subject Alternative Names (default: DNS:localhost,IP:127.0.0.1,IP:::1)
+#   -h, --help        Display this help message and exit
+#
+
+set -euo pipefail
+
+# Defaults
+CERT_DIR="certs"
+DAYS=365
+THRESHOLD_DAYS=30
+SANS="DNS:localhost,IP:127.0.0.1,IP:::1"
+CHECK_ONLY=false
+FORCE=false
+
+# Print usage
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Automate self-signed certificate generation and renewal for local development.
+
+Options:
+  --check-only       Check certificate validity without regenerating (exit 0 if valid, 1 if renewal needed)
+  --force            Force certificate regeneration even if currently valid
+  --days <N>         Certificate validity in days (default: 365)
+  --threshold <N>    Threshold in days before expiration to trigger renewal (default: 30)
+  --cert-dir <DIR>   Target directory for certificates (default: certs)
+  --san <SANS>       Subject Alternative Names (default: DNS:localhost,IP:127.0.0.1,IP:::1)
+  -h, --help         Show this help message and exit
+EOF
+    exit 0
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --check-only)
+            CHECK_ONLY=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        --threshold)
+            THRESHOLD_DAYS="$2"
+            shift 2
+            ;;
+        --cert-dir)
+            CERT_DIR="$2"
+            shift 2
+            ;;
+        --san)
+            SANS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown argument: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+# Verify openssl is available
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "Error: 'openssl' command is required but not found in PATH." >&2
+    exit 127
+fi
+
+CERT_FILE="$CERT_DIR/cert.pem"
+KEY_FILE="$CERT_DIR/key.pem"
+P12_FILE="$CERT_DIR/localhost.p12"
+
+THRESHOLD_SECONDS=$((THRESHOLD_DAYS * 86400))
+
+# Check certificate health
+check_certificate() {
+    if [[ ! -f "$CERT_FILE" || ! -f "$KEY_FILE" ]]; then
+        echo "Status: MISSING — Certificate or private key missing at '$CERT_DIR'."
+        return 1
+    fi
+
+    # Check if certificate is already expired
+    if ! openssl x509 -in "$CERT_FILE" -checkend 0 -noout >/dev/null 2>&1; then
+        local expiry_date
+        expiry_date=$(openssl x509 -in "$CERT_FILE" -enddate -noout | cut -d= -f2)
+        echo "Status: EXPIRED — Certificate expired on $expiry_date."
+        return 1
+    fi
+
+    # Check if certificate is expiring within threshold
+    if ! openssl x509 -in "$CERT_FILE" -checkend "$THRESHOLD_SECONDS" -noout >/dev/null 2>&1; then
+        local expiry_date
+        expiry_date=$(openssl x509 -in "$CERT_FILE" -enddate -noout | cut -d= -f2)
+        echo "Status: EXPIRING_SOON — Certificate expires within $THRESHOLD_DAYS days (on $expiry_date)."
+        return 1
+    fi
+
+    local expiry_date
+    expiry_date=$(openssl x509 -in "$CERT_FILE" -enddate -noout | cut -d= -f2)
+    echo "Status: VALID — Certificate is healthy and valid until $expiry_date."
+    return 0
+}
+
+# If check-only flag is set, run check and exit with appropriate code
+if [[ "$CHECK_ONLY" == "true" ]]; then
+    if check_certificate; then
+        exit 0
+    else
+        exit 1
+    fi
+fi
+
+# Determine if renewal is required
+RENEWAL_REQUIRED=false
+
+if [[ "$FORCE" == "true" ]]; then
+    echo "Renewal reason: --force flag supplied."
+    RENEWAL_REQUIRED=true
+elif ! check_certificate; then
+    RENEWAL_REQUIRED=true
+fi
+
+if [[ "$RENEWAL_REQUIRED" == "false" ]]; then
+    echo "Certificate renewal skipped: existing certificate is valid for at least $THRESHOLD_DAYS more days."
+    echo "Use --force to regenerate immediately if desired."
+    exit 0
+fi
+
+# Create target directory
+mkdir -p "$CERT_DIR"
+
+echo "Generating new self-signed certificate in '$CERT_DIR'..."
+echo "  Validity: $DAYS days"
+echo "  SANs: $SANS"
+
+# Generate private key and self-signed certificate with Subject Alternative Names
+if openssl req -x509 -nodes -newkey rsa:2048 \
+    -keyout "$KEY_FILE" \
+    -out "$CERT_FILE" \
+    -days "$DAYS" \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=$SANS" >/dev/null 2>&1; then
+    :
+else
+    # Fallback for older OpenSSL versions without -addext support
+    OPENSSL_CONF=$(mktemp)
+    cat > "$OPENSSL_CONF" << EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = localhost
+[v3_req]
+subjectAltName = $SANS
+EOF
+    openssl req -x509 -nodes -newkey rsa:2048 \
+        -keyout "$KEY_FILE" \
+        -out "$CERT_FILE" \
+        -days "$DAYS" \
+        -config "$OPENSSL_CONF" >/dev/null 2>&1
+    rm -f "$OPENSSL_CONF"
+fi
+
+# Export PKCS#12 bundle with empty password for macOS Keychain / iOS Simulator trust
+openssl pkcs12 -export \
+    -out "$P12_FILE" \
+    -inkey "$KEY_FILE" \
+    -in "$CERT_FILE" \
+    -name "Vapor Localhost Cert" \
+    -passout pass: >/dev/null 2>&1
+
+# Apply restrictive file permissions
+chmod 600 "$KEY_FILE"
+chmod 600 "$P12_FILE"
+chmod 644 "$CERT_FILE"
+
+EXPIRY=$(openssl x509 -in "$CERT_FILE" -enddate -noout | cut -d= -f2)
+
+echo "Certificate generation successful!"
+echo "  Certificate: $CERT_FILE (0644)"
+echo "  Private Key: $KEY_FILE (0600)"
+echo "  PKCS#12:     $P12_FILE (0600)"
+echo "  Valid until: $EXPIRY"
+exit 0

--- a/scripts/renew-dev-certs.sh
+++ b/scripts/renew-dev-certs.sh
@@ -23,8 +23,18 @@ CERT_DIR="certs"
 DAYS=365
 THRESHOLD_DAYS=30
 SANS="DNS:localhost,IP:127.0.0.1,IP:::1"
+P12_PASS=""
 CHECK_ONLY=false
 FORCE=false
+
+# Temp config file tracker and cleanup trap
+OPENSSL_CONF=""
+cleanup() {
+    if [[ -n "${OPENSSL_CONF:-}" && -f "${OPENSSL_CONF:-}" ]]; then
+        rm -f "$OPENSSL_CONF"
+    fi
+}
+trap cleanup EXIT INT TERM
 
 # Print usage
 usage() {
@@ -40,9 +50,67 @@ Options:
   --threshold <N>    Threshold in days before expiration to trigger renewal (default: 30)
   --cert-dir <DIR>   Target directory for certificates (default: certs)
   --san <SANS>       Subject Alternative Names (default: DNS:localhost,IP:127.0.0.1,IP:::1)
+  --p12-pass <PASS>  Password for PKCS#12 bundle (default: empty password)
   -h, --help         Show this help message and exit
 EOF
     exit 0
+}
+
+# Validate each comma-separated SAN token
+validate_sans() {
+    local raw_sans="$1"
+    if [[ -z "$raw_sans" ]]; then
+        echo "Error: --san cannot be empty" >&2
+        exit 1
+    fi
+
+    local IFS=','
+    local -a san_tokens
+    read -r -a san_tokens <<< "$raw_sans"
+
+    for token in "${san_tokens[@]}"; do
+        # Trim leading and trailing whitespace
+        local t="${token#"${token%%[![:space:]]*}"}"
+        t="${t%"${t##*[![:space:]]}"}"
+
+        if [[ -z "$t" ]]; then
+            echo "Error: empty SAN token found in '$raw_sans'" >&2
+            exit 1
+        fi
+
+        if [[ "$t" =~ ^DNS:[A-Za-z0-9.-]+$ ]]; then
+            local hostname="${t#DNS:}"
+            # Disallow underscores in DNS hostnames (RFC 1035 / RFC 1123)
+            if [[ "$hostname" == *"_"* ]]; then
+                echo "Error: invalid DNS SAN '$t': underscores are not permitted in DNS hostnames." >&2
+                exit 1
+            fi
+            # Disallow leading or trailing dot or hyphen
+            if [[ "$hostname" == .* || "$hostname" == *. || "$hostname" == -* || "$hostname" == *- ]]; then
+                echo "Error: invalid DNS SAN '$t': cannot start or end with '.' or '-'." >&2
+                exit 1
+            fi
+        elif [[ "$t" =~ ^IP:([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|[0-9a-fA-F:]+)$ ]]; then
+            local ip="${t#IP:}"
+            # If IPv4, validate octets <= 255
+            if [[ "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                local oIFS="$IFS"
+                IFS='.'
+                local -a octets
+                read -r -a octets <<< "$ip"
+                IFS="$oIFS"
+                for octet in "${octets[@]}"; do
+                    if (( octet > 255 )); then
+                        echo "Error: invalid IPv4 address in SAN '$t': octet $octet exceeds 255." >&2
+                        exit 1
+                    fi
+                done
+            fi
+        else
+            echo "Error: invalid SAN token '$t'. Only well-formed 'DNS:<hostname>' and 'IP:<address>' entries are permitted." >&2
+            exit 1
+        fi
+    done
 }
 
 # Parse command-line arguments
@@ -87,12 +155,12 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --san)
-            # Whitelist SAN characters to prevent command/config injection: alphanumeric, commas, dots, colons, hyphens, underscores
-            if ! [[ "$2" =~ ^[A-Za-z0-9_.:,-]+$ ]]; then
-                echo "Error: --san contains invalid characters. Only alphanumeric, commas, dots, colons, hyphens, and underscores are allowed." >&2
-                exit 1
-            fi
+            validate_sans "$2"
             SANS="$2"
+            shift 2
+            ;;
+        --p12-pass)
+            P12_PASS="$2"
             shift 2
             ;;
         -h|--help)
@@ -104,6 +172,9 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Validate default SANs
+validate_sans "$SANS"
 
 # Verify openssl is available
 if ! command -v openssl >/dev/null 2>&1; then
@@ -212,14 +283,14 @@ EOF
 fi
 
 # Export PKCS#12 bundle for macOS Keychain / iOS Simulator trust.
-# NOTE: Uses empty password (pass:) for zero-friction local development/simulator import.
-# Protected by filesystem mode 0600 (read/write only by owner) and strictly restricted to development.
+# NOTE: Defaults to empty password (pass:) for zero-friction local development/simulator import,
+# or accepts --p12-pass for protected exports. Protected by filesystem mode 0600.
 openssl pkcs12 -export \
     -out "$P12_FILE" \
     -inkey "$KEY_FILE" \
     -in "$CERT_FILE" \
     -name "Vapor Localhost Cert" \
-    -passout pass: >/dev/null 2>&1
+    -passout "pass:$P12_PASS" >/dev/null 2>&1
 
 # Restore previous umask and ensure public certificate is readable (0644)
 umask "$OLD_UMASK"

--- a/scripts/renew-dev-certs.sh
+++ b/scripts/renew-dev-certs.sh
@@ -57,18 +57,41 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --days)
+            if ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -lt 1 ]; then
+                echo "Error: --days must be a positive integer" >&2
+                exit 1
+            fi
             DAYS="$2"
             shift 2
             ;;
         --threshold)
+            if ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -lt 0 ]; then
+                echo "Error: --threshold must be a non-negative integer" >&2
+                exit 1
+            fi
             THRESHOLD_DAYS="$2"
             shift 2
             ;;
         --cert-dir)
+            if [[ "$2" =~ \.\. ]]; then
+                echo "Error: --cert-dir cannot contain directory traversal '..'" >&2
+                exit 1
+            fi
+            case "$2" in
+                /|/etc|/etc/*|/dev|/dev/*|/sys|/sys/*|/proc|/proc/*|/bin|/bin/*|/usr|/usr/*|/sbin|/sbin/*)
+                    echo "Error: --cert-dir cannot target sensitive system directories" >&2
+                    exit 1
+                    ;;
+            esac
             CERT_DIR="$2"
             shift 2
             ;;
         --san)
+            # Whitelist SAN characters to prevent command/config injection: alphanumeric, commas, dots, colons, hyphens, underscores
+            if ! [[ "$2" =~ ^[A-Za-z0-9_.:,-]+$ ]]; then
+                echo "Error: --san contains invalid characters. Only alphanumeric, commas, dots, colons, hyphens, and underscores are allowed." >&2
+                exit 1
+            fi
             SANS="$2"
             shift 2
             ;;
@@ -155,13 +178,17 @@ echo "Generating new self-signed certificate in '$CERT_DIR'..."
 echo "  Validity: $DAYS days"
 echo "  SANs: $SANS"
 
+# Set restrictive umask (0077) before file creation to prevent private key exposure race condition
+OLD_UMASK=$(umask)
+umask 0077
+
 # Generate private key and self-signed certificate with Subject Alternative Names
 if openssl req -x509 -nodes -newkey rsa:2048 \
     -keyout "$KEY_FILE" \
     -out "$CERT_FILE" \
     -days "$DAYS" \
     -subj "/CN=localhost" \
-    -addext "subjectAltName=$SANS" >/dev/null 2>&1; then
+    -addext "subjectAltName=${SANS}" >/dev/null 2>&1; then
     :
 else
     # Fallback for older OpenSSL versions without -addext support
@@ -174,7 +201,7 @@ prompt = no
 [req_distinguished_name]
 CN = localhost
 [v3_req]
-subjectAltName = $SANS
+subjectAltName = ${SANS}
 EOF
     openssl req -x509 -nodes -newkey rsa:2048 \
         -keyout "$KEY_FILE" \
@@ -184,7 +211,9 @@ EOF
     rm -f "$OPENSSL_CONF"
 fi
 
-# Export PKCS#12 bundle with empty password for macOS Keychain / iOS Simulator trust
+# Export PKCS#12 bundle for macOS Keychain / iOS Simulator trust.
+# NOTE: Uses empty password (pass:) for zero-friction local development/simulator import.
+# Protected by filesystem mode 0600 (read/write only by owner) and strictly restricted to development.
 openssl pkcs12 -export \
     -out "$P12_FILE" \
     -inkey "$KEY_FILE" \
@@ -192,7 +221,8 @@ openssl pkcs12 -export \
     -name "Vapor Localhost Cert" \
     -passout pass: >/dev/null 2>&1
 
-# Apply restrictive file permissions
+# Restore previous umask and ensure public certificate is readable (0644)
+umask "$OLD_UMASK"
 chmod 600 "$KEY_FILE"
 chmod 600 "$P12_FILE"
 chmod 644 "$CERT_FILE"

--- a/scripts/renew-dev-certs.sh
+++ b/scripts/renew-dev-certs.sh
@@ -22,6 +22,8 @@ set -euo pipefail
 CERT_DIR="certs"
 DAYS=365
 THRESHOLD_DAYS=30
+# Default SAN includes localhost, IPv4 loopback (127.0.0.1), and IPv6 loopback (::1).
+# Note: "IP:::1" represents OpenSSL's "IP:" prefix concatenated with the IPv6 loopback literal "::1".
 SANS="DNS:localhost,IP:127.0.0.1,IP:::1"
 P12_PASS=""
 CHECK_ONLY=false


### PR DESCRIPTION
## Summary
Resolves #9

This PR implements automated self-signed certificate management and renewal for local development, preventing developer disruption when development TLS certificates expire.

### Changes Included
1. **CertificateManager Service (`CertificateManager.swift`)**:
   - Inspects existing X.509 certificate expiry dates (`checkCertificateStatus`) using `openssl x509 -enddate -checkend`.
   - Automatically generates or renews certificates (`renewDevelopmentCertificates`) with 2048-bit RSA keys, 365-day validity, Subject Alternative Names (`DNS:localhost, IP:127.0.0.1, IP:::1`), and PKCS#12 bundle (`localhost.p12`).
   - Implements strict file permissions: `0600` for private keys and PKCS#12 bundles, `0644` for public certificates.
   - **Production Safeguard**: Throws `Abort(.internalServerError)` if invoked in a production environment (`app.environment == .production`).

2. **Pre-flight Startup Check (`configure.swift`)**:
   - In `configureTLS()`, runs `CertificateManager.ensureDevelopmentCertificates(app: app)` when `ENABLE_HTTPS=true` in development before NIOSSL attempts to load certificate files.

3. **Standalone Shell Tool (`scripts/renew-dev-certs.sh`)**:
   - Executable bash script supporting `--check-only`, `--force`, `--cert-dir <dir>`, `--days <days>`, and `--threshold <days>`.
   - Generates modern SAN extensions with fallback config for older OpenSSL versions.

4. **Configuration Controls (`AppConfig.swift`, `.env.example`)**:
   - `AUTO_RENEW_DEV_CERTS`: default `true` in development, `false` in production and testing.
   - `DEV_CERT_RENEWAL_THRESHOLD_DAYS`: default `30` days before expiration.

5. **Documentation & Architecture Specs**:
   - `Specs/automate-self-signed-certificate-renewal/spec.md`: Formal specification following SDD guidelines.
   - `Specs/automate-self-signed-certificate-renewal/architecture.md`: Architecture document with flowcharts and failure mode analyses.
   - `README.md`: Added development HTTPS setup and manual/automated renewal documentation.

6. **Comprehensive Test Suite (`StudentAppBackendTests.swift`)**:
   - 8 new unit and integration tests covering certificate inspection, threshold detection, file permissions (`0600`/`0644`), idempotency, production safeguard, AppConfig defaults, and CLI script execution.
   - All **115 / 115 tests passing**.

### Verification
- `swift test`: 115 tests passed.
- Executed `./scripts/renew-dev-certs.sh --check-only` -> Valid certificate confirmed.
- Verified `.env` is uncommitted and gitignored.
